### PR TITLE
Fix issue #3: Service Bus producer tests now exercise generated code

### DIFF
--- a/xrcg/templates/cs/sbproducer/test/ProducerTest.cs.jinja
+++ b/xrcg/templates/cs/sbproducer/test/ProducerTest.cs.jinja
@@ -20,6 +20,10 @@ using Microsoft.Extensions.Logging;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Networks;
+{%- for messagegroupid, messagegroup in messagegroups.items() %}
+{%- set groupname = messagegroupid  | pascal %}
+using {{ groupname | concat_namespace(project_name) | pascal }};
+{%- endfor %}
 
 namespace {{ project_name | pascal }}.Test
 {
@@ -204,6 +208,8 @@ namespace {{ project_name | pascal }}.Test
         {%- for messageid, message in messagegroup.messages.items() %}
         {%- set messagename = messageid | strip_namespace | pascal %}
         {%- set is_amqp = amqp.is_amqp(message) %}
+        {%- set isCloudEvent = cloudEvents.isCloudEvent(message) %}
+        {%- set uriargs = cloudEvents.DeclareUriTemplateArguments(message) %}
         [Fact]
         public async Task Test{{ messagename }}Message()
         {
@@ -216,11 +222,19 @@ namespace {{ project_name | pascal }}.Test
                 {
                     {%- if message_body_type != "byte[]" %}
                     var eventDataInstance = new {{ message_body_type }}Tests().CreateInstance();
-                    var message = new ServiceBusMessage(eventDataInstance.ToString()); // Serialize if needed
                     {%- else %}
-                    var message = new ServiceBusMessage(new byte[0]);
+                    var eventDataInstance = new byte[0];
                     {%- endif %}
-
+                    
+                    // Use generated EventFactory to create the message
+                    var message = {{ pascal_group_name | strip_namespace }}EventFactory.Create{{ messagename }}Event(
+                        eventDataInstance
+                        {%- if uriargs %}
+                        {%- for arg in uriargs.split(',') if arg.strip() %}
+                        {%- set splitarg = arg.strip().split(' ')%}
+                        , "test-{{ splitarg[1] }}"
+                        {%- endfor -%}
+                        {%- endif %});
                     await _sender.SendMessageAsync(message);
                 }
                 _logger.LogInformation("5 test messages for {{ messagename }} sent.");
@@ -239,21 +253,25 @@ namespace {{ project_name | pascal }}.Test
             try
             {   
                 {%- set message_body_type = util.body_type(data_project_name, root, message) -%}
-                {%- if message_body_type != "byte[]" %}
-                var eventDataTest = new {{ message_body_type }}Tests();
                 var eventDataInstances = new ServiceBusMessage[10];
                 for (int i = 0; i < 10; i++)
                 {
-                    var instance = eventDataTest.CreateInstance();
-                    eventDataInstances[i] = new ServiceBusMessage(instance.ToString()); // Serialize if needed
+                    {%- if message_body_type != "byte[]" %}
+                    var eventDataInstance = new {{ message_body_type }}Tests().CreateInstance();
+                    {%- else %}
+                    var eventDataInstance = new byte[0];
+                    {%- endif %}
+                    
+                    // Use generated EventFactory to create the message
+                    eventDataInstances[i] = {{ pascal_group_name | strip_namespace }}EventFactory.Create{{ messagename }}Event(
+                        eventDataInstance
+                        {%- if uriargs %}
+                        {%- for arg in uriargs.split(',') if arg.strip() %}
+                        {%- set splitarg = arg.strip().split(' ')%}
+                        , "test-{{ splitarg[1] }}"
+                        {%- endfor -%}
+                        {%- endif %});
                 }
-                {%- else %}
-                var eventDataInstances = new ServiceBusMessage[10];
-                for (int i = 0; i < 10; i++)
-                {
-                    eventDataInstances[i] = new ServiceBusMessage(new byte[0]);
-                }
-                {%- endif %}
 
                 using ServiceBusMessageBatch messageBatch = await _sender.CreateMessageBatchAsync();
                 foreach (var eventData in eventDataInstances)

--- a/xrcg/templates/java/sbproducer/src/test/java/{classdir}/ProducerTest.java.jinja
+++ b/xrcg/templates/java/sbproducer/src/test/java/{classdir}/ProducerTest.java.jinja
@@ -174,6 +174,7 @@ public class ProducerTest {
 
     {%- for messagegroupid, messagegroup in messagegroups.items() %}
     {%- set groupname = messagegroupid | pascal | strip_namespace %}
+    {%- set group_package = (package_name ~ "." ~ messagegroupid) | lower | replace('-', '_') %}
     
     @Test
     @DisplayName("Test {{ groupname }}Producer with Service Bus Emulator")
@@ -192,7 +193,25 @@ public class ProducerTest {
         
         logger.info("{{ groupname }}Producer created successfully with emulator");
         
-        // TODO: Add message sending tests here when message types are available
+        {%- for messageid, message in messagegroup.messages.items() %}
+        {%- set messagename = messageid | pascal | strip_namespace %}
+        {%- set message_body_type = util.get_data_type(data_project_name, root, message) %}
+        
+        // Test {{ messagename }} message
+        try {
+            logger.info("Testing {{ messagename }} message");
+            {%- if message_body_type != "byte[]" %}
+            {{ message_body_type }} testData = {{ message_body_type }}Tests.createInstance();
+            {%- else %}
+            byte[] testData = new byte[0];
+            {%- endif %}
+            producer.send{{ messagename }}(testData).get();
+            logger.info("Successfully sent {{ messagename }} message");
+        } catch (Exception e) {
+            logger.error("Error sending {{ messagename }} message", e);
+            fail("Failed to send {{ messagename }} message: " + e.getMessage());
+        }
+        {%- endfor %}
         
         try {
             producer.close();


### PR DESCRIPTION
This PR fixes issue #3 by updating the Service Bus producer test templates to actually exercise the generated producer code instead of directly using the Azure SDK.

## Changes

### Java Template
- Tests now call producer.send{{MessageName}}(testData).get() methods
- Uses {{MessageType}}Tests.createInstance() for schema-compliant test data
- Replaced TODO comments with actual implementation

### C# Template
- Tests now use {{GroupName}}EventFactory.Create{{MessageName}}Event() to create messages
- Added using statements for message group namespaces
- Properly passes URI template placeholder values for CloudEvents attributes

## Testing

Both templates were tested with pytest:
- C# tests: Passed in 1m07s
- Java tests: Passed in 6m13s (3 tests)

Fixes #3