### PR TITLE
chore: Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+# Dependabot configuration for xRegistry Code Generation CLI
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (main project)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Java dependencies (.NET 9.0 central dependency file)
+  - package-ecosystem: "nuget"
+    directory: "/xrcg/dependencies/cs/net90"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "csharp"
+      - "net90"
+    open-pull-requests-limit: 5
+
+  # C# dependencies (.NET 8.0 central dependency file)
+  - package-ecosystem: "nuget"
+    directory: "/xrcg/dependencies/cs/net80"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "csharp"
+      - "net80"
+    open-pull-requests-limit: 5
+
+  # Java dependencies (JDK 21 central dependency file)
+  - package-ecosystem: "maven"
+    directory: "/xrcg/dependencies/java/jdk21"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "java"
+      - "jdk21"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

This PR adds a Dependabot configuration to automatically create PRs for dependency updates across all package ecosystems used in the project.

## Configured Ecosystems

| Ecosystem | Directory | Purpose |
|-----------|-----------|---------|
| pip | / | Python dependencies from pyproject.toml |
| github-actions | / | GitHub Actions workflow dependencies |
| nuget | /xrcg/dependencies/cs/net90 | C# .NET 9.0 central dependency file |
| nuget | /xrcg/dependencies/cs/net80 | C# .NET 8.0 central dependency file |
| maven | /xrcg/dependencies/java/jdk21 | Java JDK 21 central dependency file |

## Central Dependency Files

The C# and Java directories contain pretend project files that:
1. List all dependencies used by generated code templates
2. Are monitored by Dependabot for version updates
3. Are read by the dependency() function in templates to emit current versions

This approach ensures generated code always uses up-to-date, consistent dependency versions.

## Schedule

All ecosystems are configured to check for updates weekly on Mondays with a limit of 5 open PRs per ecosystem.