### PR TITLE
feat: Add central dependency management for TypeScript, Go, and Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,113 @@
+# Dependabot configuration for xRegistry Code Generation CLI
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Python dependencies (main project)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # C# dependencies (.NET 9.0 central dependency file)
+  - package-ecosystem: "nuget"
+    directory: "/xrcg/dependencies/cs/net90"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "csharp"
+      - "net90"
+    open-pull-requests-limit: 5
+
+  # C# dependencies (.NET 8.0 central dependency file)
+  - package-ecosystem: "nuget"
+    directory: "/xrcg/dependencies/cs/net80"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "csharp"
+      - "net80"
+    open-pull-requests-limit: 5
+
+  # Java dependencies (JDK 21 central dependency file)
+  - package-ecosystem: "maven"
+    directory: "/xrcg/dependencies/java/jdk21"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "java"
+      - "jdk21"
+    open-pull-requests-limit: 5
+
+  # TypeScript dependencies (Node 22 central dependency file)
+  - package-ecosystem: "npm"
+    directory: "/xrcg/dependencies/typescript/node22"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "typescript"
+      - "node22"
+    open-pull-requests-limit: 5
+
+  # Go dependencies (Go 1.21 central dependency file)
+  - package-ecosystem: "gomod"
+    directory: "/xrcg/dependencies/go/go121"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "go"
+      - "go121"
+    open-pull-requests-limit: 5
+
+  # Python dependencies (Python 3.12 central dependency file)
+  - package-ecosystem: "pip"
+    directory: "/xrcg/dependencies/python/py312"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+      - "py312"
+    open-pull-requests-limit: 5

--- a/xrcg/dependencies/go/go121/go.mod
+++ b/xrcg/dependencies/go/go121/go.mod
@@ -1,0 +1,11 @@
+module xrcg_dependencies
+
+go 1.21
+
+require (
+	github.com/cloudevents/sdk-go/v2 v2.15.2
+	github.com/google/uuid v1.6.0
+	github.com/segmentio/kafka-go v0.4.47
+	github.com/stretchr/testify v1.8.4
+	github.com/testcontainers/testcontainers-go v0.27.0
+)

--- a/xrcg/dependencies/python/py312/requirements.txt
+++ b/xrcg/dependencies/python/py312/requirements.txt
@@ -1,0 +1,21 @@
+# Central dependency versions for xRegistry Python code generation templates
+# This file is monitored by Dependabot and read by the dependency() function in templates
+
+# Runtime dependencies
+azure-eventhub>=5.12.1
+azure-eventhub-checkpointstoreblob-aio>=1.1.4
+azure-identity>=1.17.0
+azure-servicebus>=7.12.0
+azure-storage-blob>=12.20.0
+cloudevents>=1.10.1
+confluent-kafka>=2.4.0
+paho-mqtt>=2.1.0
+python-qpid-proton>=0.39.0
+
+# Development dependencies
+flake8>=7.1.0
+mypy>=1.10.0
+pylint>=3.2.3
+pytest>=8.2.2
+pytest-asyncio>=0.23.7
+testcontainers>=4.5.1

--- a/xrcg/dependencies/typescript/node22/package.json
+++ b/xrcg/dependencies/typescript/node22/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "xrcg-dependencies",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Central dependency versions for xRegistry TypeScript code generation templates",
+  "dependencies": {
+    "@azure/event-hubs": "^5.11.0",
+    "@azure/eventgrid": "^5.0.0",
+    "@azure/identity": "^4.0.0",
+    "@azure/service-bus": "^7.9.0",
+    "cloudevents": "^8.0.2",
+    "kafkajs": "^2.2.4",
+    "mqtt": "^5.0.0",
+    "rhea": "^3.0.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@stylistic/eslint-plugin": "^2.9.0",
+    "@testcontainers/kafka": "^11.7.2",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^22.7.5",
+    "@types/uuid": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.8.1",
+    "@typescript-eslint/parser": "^8.8.1",
+    "eslint": "^9.12.0",
+    "jest": "^29.7.0",
+    "nock": "^13.5.0",
+    "testcontainers": "^10.13.2",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.6.3"
+  }
+}


### PR DESCRIPTION
## ⚠️ Depends on PR #33

This PR has been rebased onto `fix/java-jackson-bom` branch and requires PR #33 to be merged first.

---

## Summary

This PR adds central dependency files for TypeScript, Go, and Python following the same pattern as the existing C# and Java implementations. These files enable Dependabot to monitor dependency versions and allow templates to reference current versions via the `dependency()` function.

## New Central Dependency Files

| Language | Runtime | File | Ecosystem |
|----------|---------|------|-----------|
| TypeScript | Node 22 | `xrcg/dependencies/typescript/node22/package.json` | npm |
| Go | Go 1.21 | `xrcg/dependencies/go/go121/go.mod` | gomod |
| Python | Python 3.12 | `xrcg/dependencies/python/py312/requirements.txt` | pip |

## Template Usage

Templates can now use the `dependency()` function for these languages:

```jinja
{# TypeScript #}
{{ dependency('ts', 'node22', 'kafkajs') }}
{# Output: "kafkajs": "^2.2.4" #}

{# Go #}
{{ dependency('go', 'go121', 'github.com/segmentio/kafka-go') }}
{# Output: github.com/segmentio/kafka-go v0.4.47 #}

{# Python #}
{{ dependency('py', 'py312', 'confluent-kafka') }}
{# Output: confluent-kafka = ">=2.4.0" #}
```

## Dependabot Configuration

Also includes a comprehensive `dependabot.yml` that monitors ALL dependency sources:

- **pip** - Main project (`pyproject.toml`) + Python central deps
- **github-actions** - Workflow dependencies
- **nuget** - C# .NET 8.0 and 9.0 central deps
- **maven** - Java JDK 21 central deps
- **npm** - TypeScript Node 22 central deps
- **gomod** - Go 1.21 central deps

## Changes

- `xrcg/generator/template_renderer.py`: Add Go support, update TypeScript to check devDependencies, update Python to parse requirements.txt
- New dependency files for TypeScript, Go, and Python
- New `.github/dependabot.yml` with all ecosystems

## Related

- Supersedes PR #34 (chore/add-dependabot-config) - this PR includes a more complete dependabot.yml
- **Depends on PR #33** (fix/java-jackson-bom) - this branch is rebased on top of PR #33's changes
