### PR TITLE
fix: Python kafkaproducer hyphenated imports and structured mode content-type header

### DIFF
--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -762,7 +762,7 @@ class TemplateRenderer:
     def resolve_string(template: str, replacements: Dict[str, str]):
         """Resolve a string template with placeholders using the given replacements."""
         # Regex to find placeholders with optional filter using | or !
-        pattern = re.compile(r'\{(\w+)((?:~[\w\.]+)*)(?:\s*([|!]\s*\w+\s*)*)\}')
+        pattern = re.compile(r'\{(\w+)((?:~[\w\.]+)*)((?:\s*[|!]\s*\w+\s*)*)\}')
 
         # Function to replace match with the correct value
         def replace_match(match):

--- a/xrcg/templates/py/amqpconsumer/_templateinfo.json
+++ b/xrcg/templates/py/amqpconsumer/_templateinfo.json
@@ -2,7 +2,7 @@
   "description": "Python AMQP 1.0 Consumer",
   "template_kind": "consumer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}AmqpConsumer",
-  "data_project_name": "{project_name|dotunderscore|lower}Data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}AmqpConsumer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}Data",
   "src_layout": false
 }

--- a/xrcg/templates/py/amqpproducer/_templateinfo.json
+++ b/xrcg/templates/py/amqpproducer/_templateinfo.json
@@ -2,7 +2,7 @@
   "description": "Python AMQP 1.0 Producer",
   "template_kind": "producer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}AmqpProducer",
-  "data_project_name": "{project_name|dotunderscore|lower}Data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}AmqpProducer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}Data",
   "src_layout": false
 }

--- a/xrcg/templates/py/ehconsumer/_templateinfo.json
+++ b/xrcg/templates/py/ehconsumer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Azure Event Hubs Consumer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_eventhubs_consumer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_eventhubs_consumer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/ehproducer/_templateinfo.json
+++ b/xrcg/templates/py/ehproducer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Azure Event Hubs Producer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_eventhubs_producer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_eventhubs_producer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/kafkaconsumer/_templateinfo.json
+++ b/xrcg/templates/py/kafkaconsumer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Apache Kafka Consumer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_kafka_consumer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_kafka_consumer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/kafkaproducer/_templateinfo.json
+++ b/xrcg/templates/py/kafkaproducer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Apache Kafka Producer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_kafka_producer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_kafka_producer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -130,7 +130,7 @@ class {{ class_name }}:
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: {% if data_type != "object"%}json.loads(x.to_json()){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper))
-            message.headers[b"content-type"] = b"application/cloudevents+json"
+            message.headers["content-type"] = b"application/cloudevents+json"
         else:
             # For binary mode, datacontenttype is already set in attributes above
             # The to_binary() function will create the ce_datacontenttype header

--- a/xrcg/templates/py/mqttclient/_templateinfo.json
+++ b/xrcg/templates/py/mqttclient/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python MQTT Client",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_mqtt_client",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_mqtt_client",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/sbconsumer/_templateinfo.json
+++ b/xrcg/templates/py/sbconsumer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Azure Service Bus Consumer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_servicebus_consumer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_servicebus_consumer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/sbproducer/_templateinfo.json
+++ b/xrcg/templates/py/sbproducer/_templateinfo.json
@@ -1,7 +1,7 @@
 {
   "description": "Python Azure Service Bus Producer",
   "priority": 1,
-  "main_project_name": "{project_name|dotunderscore|lower}_servicebus_producer",
-  "data_project_name": "{project_name|dotunderscore|lower}_data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_servicebus_producer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in the Python kafkaproducer code generation:

### Issue #184 — Hyphenated project names produce invalid Python imports

**Root cause:** Two problems working together:

1. **Regex bug in `resolve_string`** (`template_renderer.py`): The pattern used a capturing group inside a repeated non-capturing group. Python's `re` only keeps the **last** match of a repeated capturing group, so in `{project_name|dashdot|dotunderscore|lower}`, only `|lower` was captured and earlier filters were silently dropped.

2. **Missing hyphen-to-dot conversion**: The `_templateinfo.json` files only applied `dotunderscore` (dots to underscores) but hyphens in `--projectname` also need conversion. Added `dashdot` (hyphens to dots) before `dotunderscore` in all 9 Python template info files.

**Fix:** Changed regex from `(?:\s*([|!]\s*\w+\s*)*)` to `((?:\s*[|!]\s*\w+\s*)*)` so group 3 captures the entire filter chain. Updated all Python `_templateinfo.json` to use `{project_name|dashdot|dotunderscore|lower}`.

### Issue #185 — Structured mode content-type header with bytes key creates duplicate

**Root cause:** Template set `message.headers[b"content-type"]` (bytes key) but `cloudevents.kafka.to_structured()` already sets `message.headers["content-type"]` (string key). In Python, `"x"` and `b"x"` are different dict keys, so this created a duplicate entry. Consumers read the wrong one.

**Fix:** Changed `b"content-type"` to `"content-type"` to match the `cloudevents.kafka` SDK convention (`Dict[str, bytes]`).

### Testing

- Generated output with `--projectname usgs-earthquakes-producer` produces `usgs_earthquakes_producer_data` directories and valid `from usgs_earthquakes_producer_data import ...` statements
- All codegen tests pass (2 passed, 3 skipped)

Fixes #184
Fixes #185
