### PR TITLE
fix: Python Kafka producer uses xRegistry-declared key instead of type:source-subject

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -139,6 +139,13 @@ def test_kafkaproducer_lightbulb_py():
                         tmpdirname, "test_kafkaproducer_lightbulb_py", "kafkaproducer")
 
 
+def test_kafkaproducer_dwd_py():
+    """ Test the Kafka producer for DWD weather data with endpoint-level Kafka key templates."""
+    tmpdirname = tempfile.mkdtemp()
+    run_python_test(os.path.join(project_root, "test/xreg/dwd.xreg.json".replace(
+            '/', os.sep)), tmpdirname, "test_kafkaproducer_dwd_py", "kafkaproducer")
+
+
 def test_kafkaconsumer_contoso_erp_py():
     """ Test the Kafka consumer for Contoso ERP."""
     tmpdirname = tempfile.mkdtemp()

--- a/test/xreg/dwd.xreg.json
+++ b/test/xreg/dwd.xreg.json
@@ -1,0 +1,343 @@
+{
+  "endpoints": {
+    "DE.DWD.CDC.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "dwd",
+          "key": "{station_id}"
+        }
+      },
+      "messagegroups": [
+        "#/messagegroups/DE.DWD.CDC"
+      ]
+    },
+    "DE.DWD.Weather.Kafka": {
+      "usage": [
+        "producer"
+      ],
+      "protocol": "KAFKA",
+      "envelope": "CloudEvents/1.0",
+      "envelopeoptions": {
+        "mode": "structured",
+        "format": "application/cloudevents+json"
+      },
+      "protocoloptions": {
+        "deployed": false,
+        "options": {
+          "topic": "dwd",
+          "key": "{identifier}"
+        }
+      },
+      "messagegroups": [
+        "#/messagegroups/DE.DWD.Weather"
+      ]
+    }
+  },
+  "messagegroups": {
+    "DE.DWD.CDC": {
+      "messages": {
+        "DE.DWD.CDC.StationMetadata": {
+          "name": "StationMetadata",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "DE.DWD.CDC.StationMetadata"
+            },
+            "source": {
+              "value": "https://opendata.dwd.de"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JSONStructure/draft-02",
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.StationMetadata"
+        },
+        "DE.DWD.CDC.AirTemperature10Min": {
+          "name": "AirTemperature10Min",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "DE.DWD.CDC.AirTemperature10Min"
+            },
+            "source": {
+              "value": "https://opendata.dwd.de"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JSONStructure/draft-02",
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.AirTemperature10Min"
+        },
+        "DE.DWD.CDC.Precipitation10Min": {
+          "name": "Precipitation10Min",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "DE.DWD.CDC.Precipitation10Min"
+            },
+            "source": {
+              "value": "https://opendata.dwd.de"
+            },
+            "subject": {
+              "value": "{station_id}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JSONStructure/draft-02",
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.CDC.Precipitation10Min"
+        }
+      }
+    },
+    "DE.DWD.Weather": {
+      "messages": {
+        "DE.DWD.Weather.Alert": {
+          "name": "Alert",
+          "envelope": "CloudEvents/1.0",
+          "envelopemetadata": {
+            "type": {
+              "value": "DE.DWD.Weather.Alert"
+            },
+            "source": {
+              "value": "https://opendata.dwd.de"
+            },
+            "subject": {
+              "value": "{identifier}",
+              "type": "uritemplate"
+            }
+          },
+          "dataschemaformat": "JSONStructure/draft-02",
+          "dataschemauri": "#/schemagroups/DE.DWD.CDC.jstruct/schemas/DE.DWD.Weather.Alert"
+        }
+      }
+    }
+  },
+  "schemagroups": {
+    "DE.DWD.CDC.jstruct": {
+      "schemas": {
+        "DE.DWD.CDC.StationMetadata": {
+          "name": "StationMetadata",
+          "format": "JSONStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JSONStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "station_id",
+                  "station_name",
+                  "latitude",
+                  "longitude",
+                  "elevation"
+                ],
+                "name": "StationMetadata",
+                "properties": {
+                  "station_id": {
+                    "type": "string"
+                  },
+                  "station_name": {
+                    "type": "string"
+                  },
+                  "latitude": {
+                    "type": "double"
+                  },
+                  "longitude": {
+                    "type": "double"
+                  },
+                  "elevation": {
+                    "type": "double"
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "from_date": {
+                    "type": "string"
+                  },
+                  "to_date": {
+                    "type": "string"
+                  }
+                },
+                "$id": "https://example.com/DE/DWD/CDC/StationMetadata.schema.json",
+                "description": "StationMetadata"
+              }
+            }
+          }
+        },
+        "DE.DWD.CDC.AirTemperature10Min": {
+          "name": "AirTemperature10Min",
+          "format": "JSONStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JSONStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "station_id",
+                  "timestamp"
+                ],
+                "name": "AirTemperature10Min",
+                "properties": {
+                  "station_id": {
+                    "type": "string"
+                  },
+                  "timestamp": {
+                    "type": "string"
+                  },
+                  "quality_level": {
+                    "type": "int32"
+                  },
+                  "pressure_station_level": {
+                    "type": "double"
+                  },
+                  "air_temperature_2m": {
+                    "type": "double"
+                  },
+                  "air_temperature_5cm": {
+                    "type": "double"
+                  },
+                  "relative_humidity": {
+                    "type": "double"
+                  },
+                  "dew_point_temperature": {
+                    "type": "double"
+                  }
+                },
+                "$id": "https://example.com/DE/DWD/CDC/AirTemperature10Min.schema.json",
+                "description": "AirTemperature10Min"
+              }
+            }
+          }
+        },
+        "DE.DWD.CDC.Precipitation10Min": {
+          "name": "Precipitation10Min",
+          "format": "JSONStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JSONStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "station_id",
+                  "timestamp"
+                ],
+                "name": "Precipitation10Min",
+                "properties": {
+                  "station_id": {
+                    "type": "string"
+                  },
+                  "timestamp": {
+                    "type": "string"
+                  },
+                  "quality_level": {
+                    "type": "int32"
+                  },
+                  "precipitation_height": {
+                    "type": "double"
+                  },
+                  "precipitation_indicator": {
+                    "type": "int32"
+                  }
+                },
+                "$id": "https://example.com/DE/DWD/CDC/Precipitation10Min.schema.json",
+                "description": "Precipitation10Min"
+              }
+            }
+          }
+        },
+        "DE.DWD.Weather.Alert": {
+          "name": "Alert",
+          "format": "JSONStructure/draft-02",
+          "defaultversionid": "1",
+          "versions": {
+            "1": {
+              "format": "JSONStructure/draft-02",
+              "schema": {
+                "$schema": "https://json-structure.org/meta/extended/v0/#",
+                "type": "object",
+                "required": [
+                  "identifier",
+                  "sender",
+                  "sent",
+                  "severity",
+                  "event"
+                ],
+                "name": "Alert",
+                "properties": {
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "sender": {
+                    "type": "string"
+                  },
+                  "sent": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "msg_type": {
+                    "type": "string"
+                  },
+                  "severity": {
+                    "type": "string"
+                  },
+                  "urgency": {
+                    "type": "string"
+                  },
+                  "certainty": {
+                    "type": "string"
+                  },
+                  "event": {
+                    "type": "string"
+                  },
+                  "headline": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "effective": {
+                    "type": "string"
+                  },
+                  "onset": {
+                    "type": "string"
+                  },
+                  "expires": {
+                    "type": "string"
+                  },
+                  "area_desc": {
+                    "type": "string"
+                  },
+                  "geocodes": {
+                    "type": "string"
+                  }
+                },
+                "$id": "https://example.com/DE/DWD/Weather/Alert.schema.json",
+                "description": "Alert"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/xrcg/templates/py/_common/kafka.jinja.include
+++ b/xrcg/templates/py/_common/kafka.jinja.include
@@ -20,12 +20,13 @@ from confluent_kafka import Producer, Consumer, KafkaError, Message
 
 # Generates a list of arguments for "send" methods that correspond to placeholders in uritemplates
 {%- macro DeclareUriTemplateArguments(message) -%}
-{%- if message.protocoloptions["header"] -%}{{ EmitArguments(message.protocoloptions["header"]) }}{%- endif -%}
-{%- if message.protocoloptions["footer"] -%}{{ EmitArguments(message.protocoloptions["footer"]) }}{%- endif -%}
-{%- if message.protocoloptions["message_annotations"] -%}{{ EmitArguments(message.protocoloptions["message_annotations"]) }}{%- endif -%}
-{%- if message.protocoloptions["delivery_annotations"] -%}{{ EmitArguments(message.protocoloptions["delivery_annotations"]) }}{%- endif -%}
-{%- if message.protocoloptions["properties"] -%}{{ EmitArguments(message.protocoloptions["properties"]) }}{%- endif -%}
-{%- if message.protocoloptions["application_properties"] -%}{{ EmitArguments(message.protocoloptions["application_properties"]) }}{%- endif -%}
+{%- if message.protocoloptions is defined and message.protocoloptions -%}
+{%- if message.protocoloptions["headers"] is defined and message.protocoloptions["headers"] -%}{{ EmitArguments(message.protocoloptions["headers"]) }}{%- endif -%}
+{%- if message.protocoloptions["key"] is defined and message.protocoloptions["key"] -%}{{ EmitArguments(message.protocoloptions["key"]) }}{%- endif -%}
+{%- if message.protocoloptions["partition"] is defined and message.protocoloptions["partition"] -%}{{ EmitArguments(message.protocoloptions["partition"]) }}{%- endif -%}
+{%- if message.protocoloptions["topic"] is defined and message.protocoloptions["topic"] -%}{{ EmitArguments(message.protocoloptions["topic"]) }}{%- endif -%}
+{%- if message.protocoloptions["timestamp"] is defined and message.protocoloptions["timestamp"] -%}{{ EmitArguments(message.protocoloptions["timestamp"]) }}{%- endif -%}
+{%- endif -%}
 {%- endmacro %}
 
 # Helper macro for assigning properties
@@ -50,31 +51,29 @@ from confluent_kafka import Producer, Consumer, KafkaError, Message
 
 # Generates Kafka message objects from kafkaDefinition as message
 {%- macro DeclareMessage(variable, message) -%}
-{%- set header = message.protocoloptions["header"] %}
-{%- set footer = message.protocoloptions["footer"] %}
-{%- set messageAnnotations = message.protocoloptions["message_annotations"] %}
-{%- set deliveryAnnotations = message.protocoloptions["delivery_annotations"] %}
-{%- set properties = message.protocoloptions["properties"] %}
-{%- set applicationProperties = message.protocoloptions["application_properties"] %}
+{%- if message.protocoloptions is defined and message.protocoloptions -%}
+{%- set headers = message.protocoloptions["headers"] if "headers" in message.protocoloptions else None %}
+{%- set key = message.protocoloptions["key"] if "key" in message.protocoloptions else None %}
+{%- set partition = message.protocoloptions["partition"] if "partition" in message.protocoloptions else None %}
+{%- set topic = message.protocoloptions["topic"] if "topic" in message.protocoloptions else None %}
+{%- set timestamp = message.protocoloptions["timestamp"] if "timestamp" in message.protocoloptions else None %}
 message = Producer()
-{%- if header %}
-{{- AssignProps("message.headers", header, True) }}
+{%- if headers %}
+{{- AssignProps("message.headers", headers, True) }}
 {%- endif %}
-{%- if footer %}
-{{- AssignProps("message.headers", footer, True) }}
+{%- if key %}
+{{- AssignProps("message.key", key) }}
 {%- endif %}
-{%- if messageAnnotations %}
-{{- AssignProps("message.headers", messageAnnotations, True) }}
+{%- if partition %}
+{{- AssignProps("message.partition", partition) }}
 {%- endif %}
-{%- if deliveryAnnotations %}
-{{- AssignProps("message.headers", deliveryAnnotations, True) }}
+{%- if topic %}
+{{- AssignProps("message.topic", topic) }}
 {%- endif %}
-{%- if properties %}
-{{- AssignProps("message.headers", properties, True) }}
+{%- if timestamp %}
+{{- AssignProps("message.timestamp", timestamp) }}
 {%- endif %}
-{%- if applicationProperties %}
-{{- AssignProps("message.headers", applicationProperties, True) }}
-{%- endif %}
+{%- endif -%}
 {%- endmacro -%}
 
 {%- macro DeclareDispatchObjectField(project_name, messagegroups, withType) -%}

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -31,6 +31,21 @@ from cloudevents.http import CloudEvent
 {%- set groupName = parts | join('_') | lower %}
 {%- set groupname = messagegroupid | pascal %}
 {%- set class_name = ( groupname | strip_dots ) + "EventProducer" %}
+{#- Look up Kafka key template from endpoint protocoloptions for this message group -#}
+{%- set endpoint_kafka_key = [] %}
+{%- if root.endpoints %}
+{%- for endpointid, ep in root.endpoints.items() %}
+{%- if "protocol" in ep and ep.protocol | lower == "kafka" and "messagegroups" in ep and ep.messagegroups %}
+{%- for mgref in ep.messagegroups %}
+{%- if mgref == "#/messagegroups/" + messagegroupid %}
+{%- if "protocoloptions" in ep and "options" in ep.protocoloptions and "key" in ep.protocoloptions.options %}
+{%- set _ = endpoint_kafka_key.append(ep.protocoloptions.options.key) %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
 
 class {{ class_name }}:
     def __init__(self, producer: Producer, topic: str, content_mode:typing.Literal['structured','binary']='structured'):
@@ -46,7 +61,8 @@ class {{ class_name }}:
         self.topic = topic
         self.content_mode = content_mode
 
-    def __key_mapper(self, x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str]) -> str:
+    @staticmethod
+    def __key_mapper(x: CloudEvent, m: typing.Any, key_mapper: typing.Callable[[CloudEvent, typing.Any], str], default_key: typing.Optional[str] = None) -> typing.Optional[str]:
         """
         Maps a CloudEvent to a Kafka key
 
@@ -54,14 +70,31 @@ class {{ class_name }}:
             x (CloudEvent): The CloudEvent to map
             m (Any): The event data
             key_mapper (Callable[[CloudEvent, Any], str]): The user's key mapper function
+            default_key (Optional[str]): The resolved key from the xRegistry model declaration
         """
         if key_mapper:
             return key_mapper(x, m)
-        else:
-            return f'{str(x.get("type"))}:{str(x.get("source"))}{("-"+str(x.get("subject"))) if x.get("subject") else ""}'
+        elif default_key is not None:
+            return default_key
+        return f"{x['type']}:{x['source']}-{x.get('subject', '')}"
     {%- for messageid, message in messagegroup.messages.items() -%}
     {%- set message_snake = messageid | dotunderscore | snake %}
     {%- set data_type = util.DeclareDataType( data_project_name, root, message ) %}
+    {#- Determine the Kafka key for this message: message-level protocolmetadata wins, then endpoint-level -#}
+    {%- set msg_key_holder = [] %}
+    {%- if "protocolmetadata" in message and "key" in message.protocolmetadata and "value" in message.protocolmetadata.key %}
+    {%- set _ = msg_key_holder.append(message.protocolmetadata.key.value) %}
+    {%- elif endpoint_kafka_key %}
+    {%- set _ = msg_key_holder.append(endpoint_kafka_key[-1]) %}
+    {%- endif %}
+    {%- set kafka_key_value = msg_key_holder[0] if msg_key_holder else None %}
+    {#- Collect already-declared envelope URI template placeholders -#}
+    {%- set declared_params = [] %}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+    {%- for ph in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+    {%- if (ph | snake) not in declared_params %}{%- set _ = declared_params.append(ph | snake) %}{%- endif %}
+    {%- endfor -%}
+    {%- endfor %}
 
     def send_{{message_snake}}(self,
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata -%}
@@ -73,6 +106,11 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
         {%- endfor -%}
+        {%- if kafka_key_value -%}
+            {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+                {%- if (placeholder | snake) not in declared_params %}_{{ placeholder | snake }}: str, {% endif -%}
+            {%- endfor -%}
+        {%- endif -%}
         data: {{ data_type | strip_namespace -}}, content_type: str = "application/json"
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
             , _{{ attrname }}: typing.Optional[str] = None
@@ -92,15 +130,34 @@ class {{ class_name }}:
             _{{ placeholder | snake }}(str):  Value for placeholder {{ placeholder }} in attribute {{ attrname }}
             {%- endfor -%}
         {%- endfor %}
+        {%- if kafka_key_value %}
+            {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+            {%- if (placeholder | snake) not in declared_params %}
+            _{{ placeholder | snake }}(str): Value for Kafka key placeholder '{{ placeholder }}'
+            {%- endif -%}
+            {%- endfor %}
+        {%- endif %}
             data: ({{ data_type | strip_namespace -}}): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
-            key_mapper(Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]): A function to map the CloudEvent contents to a Kafka key (default: None). 
-                The default key mapper maps the CloudEvent type, source, and subject to the Kafka key
+            key_mapper(Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
+        {%- if kafka_key_value %}
+                The default key is derived from the xRegistry Kafka key declaration '{{ kafka_key_value }}'
+        {%- endif %}
         """
+        {%- if kafka_key_value %}
+        {%- set kphs = kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- if kphs %}
+        kafka_key = "{{ kafka_key_value }}".format({% for ph in kphs %}{{ ph }}=_{{ ph | snake }}{% if not loop.last %}, {% endif %}{% endfor %})
+        {%- else %}
+        kafka_key = "{{ kafka_key_value }}"
+        {%- endif %}
+        {%- else %}
+        kafka_key = None
+        {%- endif %}
         attributes = {
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
              "{{ attrname }}": _{{ attrname }},
@@ -129,12 +186,12 @@ class {{ class_name }}:
         attributes["datacontenttype"] = content_type
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
-            message = to_structured(event, data_marshaller=lambda x: {% if data_type != "object"%}json.loads(x.to_json()){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper))
+            message = to_structured(event, data_marshaller=lambda x: {% if data_type != "object"%}json.loads(x.to_json()){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
             message.headers["content-type"] = b"application/cloudevents+json"
         else:
             # For binary mode, datacontenttype is already set in attributes above
             # The to_binary() function will create the ce_datacontenttype header
-            message = to_binary(event, data_marshaller=lambda x: {% if data_type != "object"%}x.to_byte_array("application/json"){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper))
+            message = to_binary(event, data_marshaller=lambda x: {% if data_type != "object"%}x.to_byte_array("application/json"){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))
         self.producer.produce(self.topic, key=message.key, value=message.value, headers=message.headers)
         if flush_producer:
             self.producer.flush()

--- a/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
@@ -84,13 +84,41 @@ def parse_cloudevent(msg: Message) -> CloudEvent:
         ce = from_binary(message)
         ce['datacontenttype'] = 'application/json'
     return ce
-
-{%- for messagegroupid, messagegroup in root.messagegroups.items() %}
+{% for messagegroupid, messagegroup in root.messagegroups.items() %}
 {%- set groupname = messagegroupid | pascal %}
 {%- set class_name = ( groupname | strip_dots ) + "EventProducer" %}
+{#- Look up Kafka key template from endpoint for this message group -#}
+{%- set endpoint_kafka_key = [] %}
+{%- if root.endpoints %}
+{%- for endpointid, ep in root.endpoints.items() %}
+{%- if "protocol" in ep and ep.protocol | lower == "kafka" and "messagegroups" in ep and ep.messagegroups %}
+{%- for mgref in ep.messagegroups %}
+{%- if mgref == "#/messagegroups/" + messagegroupid %}
+{%- if "protocoloptions" in ep and "options" in ep.protocoloptions and "key" in ep.protocoloptions.options %}
+{%- set _ = endpoint_kafka_key.append(ep.protocoloptions.options.key) %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
 {%- for messageid, message in messagegroup.messages.items() %}
 {%- set messagename = messageid | pascal | strip_dots | strip_namespace %}
 {%- set test_function_name = "test_" + groupname | lower | replace(" ", "_") + "_" + messagename | lower | replace(" ", "_") %}
+{#- Determine Kafka key for this message -#}
+{%- set msg_key_holder = [] %}
+{%- if "protocolmetadata" in message and "key" in message.protocolmetadata and "value" in message.protocolmetadata.key %}
+{%- set _ = msg_key_holder.append(message.protocolmetadata.key.value) %}
+{%- elif endpoint_kafka_key %}
+{%- set _ = msg_key_holder.append(endpoint_kafka_key[-1]) %}
+{%- endif %}
+{%- set kafka_key_value = msg_key_holder[0] if msg_key_holder else None %}
+{%- set declared_params = [] %}
+{%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+{%- for ph in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+{%- if (ph | snake) not in declared_params %}{%- set _ = declared_params.append(ph | snake) %}{%- endif %}
+{%- endfor -%}
+{%- endfor %}
 
 def {{ test_function_name | dotunderscore }}(kafka_emulator):
     """Test the {{ messagename }} event from the {{ groupname }} message group"""
@@ -124,7 +152,7 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
         timeout = time.time() + 20  # 20 second timeout for CI robustness
         while True:
             if time.time() > timeout:
-                return False
+                return None
             msg = consumer.poll(1.0)
             if msg is None:
                 continue
@@ -132,7 +160,7 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
                 continue
             cloudevent = parse_cloudevent(msg)
             if cloudevent['type'] == "{{ messageid }}":
-                return True
+                return msg.key().decode('utf-8') if msg.key() else None
 
     kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
     producer_instance = {{ class_name }}(kafka_producer, topic, 'binary')
@@ -153,6 +181,11 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
             {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
                 {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
             {%- endfor -%}
+            {%- if kafka_key_value -%}
+                {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+                    {%- if (placeholder | snake) not in declared_params %}_{{ placeholder | snake }} = f'test_{i}', {% endif -%}
+                {%- endfor -%}
+            {%- endif -%}
             data = event_data
             {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
                 , _{{ attrname }} = ''
@@ -162,10 +195,168 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
     # Flush producer to ensure messages are sent before consumer polling
     kafka_producer.flush(timeout=5.0)
 
-    # Verify all 5 messages received
+    # Verify all 5 messages received and assert Kafka key
     for i in range(5):
-        assert on_event(), f"Failed to receive message {i+1} of 5"
+        received_key = on_event()
+        assert received_key is not None, f"Failed to receive message {i+1} of 5"
+        {%- if kafka_key_value %}
+        {%- set kphs = kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- if kphs %}
+        expected_key = "{{ kafka_key_value }}".format({% for ph in kphs %}{{ ph }}=f'test_{i}'{% if not loop.last %}, {% endif %}{% endfor %})
+        assert received_key == expected_key, f"Expected Kafka key '{expected_key}' but got '{received_key}'"
+        {%- else %}
+        assert received_key == "{{ kafka_key_value }}", f"Expected Kafka key '{{ kafka_key_value }}' but got '{received_key}'"
+        {%- endif %}
+        {%- endif %}
     consumer.close()
-
+{% endfor %}
 {%- endfor %}
+
+{#- Cross-event-type Kafka key test: verifies that different event types with the same
+    key template in a message group produce the same Kafka key for the same placeholder values -#}
+{%- for messagegroupid, messagegroup in root.messagegroups.items() %}
+{%- set groupname = messagegroupid | pascal %}
+{%- set class_name = ( groupname | strip_dots ) + "EventProducer" %}
+{#- Look up Kafka key template from endpoint for this message group -#}
+{%- set ep_key_holder = [] %}
+{%- if root.endpoints %}
+{%- for endpointid, ep in root.endpoints.items() %}
+{%- if "protocol" in ep and ep.protocol | lower == "kafka" and "messagegroups" in ep and ep.messagegroups %}
+{%- for mgref in ep.messagegroups %}
+{%- if mgref == "#/messagegroups/" + messagegroupid %}
+{%- if "protocoloptions" in ep and "options" in ep.protocoloptions and "key" in ep.protocoloptions.options %}
+{%- set _ = ep_key_holder.append(ep.protocoloptions.options.key) %}
+{%- endif %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- set group_kafka_key = ep_key_holder[0] if ep_key_holder else None %}
+{#- Only generate cross-event-type test when group has >=2 messages sharing same key template -#}
+{%- if group_kafka_key and messagegroup.messages | length >= 2 %}
+{%- set msg_list = messagegroup.messages.items() | list %}
+
+def test_{{ groupname | lower | replace(" ", "_") | dotunderscore }}_cross_event_type_kafka_key(kafka_emulator):
+    """Test that different event types in {{ groupname }} produce the same Kafka key for the same placeholder values"""
+
+    bootstrap_servers = kafka_emulator["bootstrap_servers"]
+    topic = kafka_emulator["topic"]
+
+    consumer = Consumer({
+        'bootstrap.servers': bootstrap_servers,
+        'group.id': 'test_{{ groupname | lower | dotunderscore }}_cross_key',
+        'auto.offset.reset': 'latest'
+    })
+    consumer.subscribe([topic])
+
+    import time
+    assignment_timeout = time.time() + 10
+    while not consumer.assignment() and time.time() < assignment_timeout:
+        consumer.poll(0.1)
+    if not consumer.assignment():
+        pytest.fail(f"Consumer failed to get partition assignment within 10 seconds. Topic: {topic}")
+    # Drain any pre-existing messages before producing our test messages
+    drain_timeout = time.time() + 3
+    while time.time() < drain_timeout:
+        msg = consumer.poll(0.5)
+    time.sleep(1)
+
+    kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})
+    producer_instance = {{ class_name }}(kafka_producer, topic, 'binary')
+
+    shared_key_value = "shared_entity_42"
+
+    {#- Send one message of each of the first two message types with the same key placeholder -#}
+    {%- set first_msg_id = msg_list[0][0] %}
+    {%- set first_msg = msg_list[0][1] %}
+    {%- set second_msg_id = msg_list[1][0] %}
+    {%- set second_msg = msg_list[1][1] %}
+    {%- set first_type_name = util.DeclareDataType( data_project_name, root, first_msg ) %}
+    {%- set second_type_name = util.DeclareDataType( data_project_name, root, second_msg ) %}
+
+    {%- if first_type_name != "object" %}
+    data1 = Test_{{ first_type_name | pascal | strip_namespace }}.create_instance()
+    {%- else %}
+    data1 = {}
+    {%- endif %}
+    {%- if second_type_name != "object" %}
+    data2 = Test_{{ second_type_name | pascal | strip_namespace }}.create_instance()
+    {%- else %}
+    data2 = {}
+    {%- endif %}
+
+    producer_instance.send_{{ first_msg_id | dotunderscore | snake }}(
+        {%- for attrname, attribute in first_msg.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
+            _{{ attrname }} = 'test',
+        {%- endfor -%}
+        {%- for attrname, attribute in first_msg.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = shared_key_value, {% endfor -%}
+        {%- endfor -%}
+        {%- set first_msg_declared_params = [] %}
+        {%- for attrname, attribute in first_msg.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+        {%- for ph in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- if (ph | snake) not in first_msg_declared_params %}{%- set _ = first_msg_declared_params.append(ph | snake) %}{%- endif %}
+        {%- endfor -%}
+        {%- endfor -%}
+        {%- if group_kafka_key -%}
+            {%- for placeholder in group_kafka_key | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+                {%- if (placeholder | snake) not in first_msg_declared_params %}_{{ placeholder | snake }} = shared_key_value, {% endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+        data = data1
+        {%- for attrname, attribute in first_msg.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+            , _{{ attrname }} = ''
+        {%- endfor -%}
+    )
+    producer_instance.send_{{ second_msg_id | dotunderscore | snake }}(
+        {%- for attrname, attribute in second_msg.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
+            _{{ attrname }} = 'test',
+        {%- endfor -%}
+        {%- for attrname, attribute in second_msg.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = shared_key_value, {% endfor -%}
+        {%- endfor -%}
+        {%- set second_msg_declared_params = [] %}
+        {%- for attrname, attribute in second_msg.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+        {%- for ph in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- if (ph | snake) not in second_msg_declared_params %}{%- set _ = second_msg_declared_params.append(ph | snake) %}{%- endif %}
+        {%- endfor -%}
+        {%- endfor -%}
+        {%- if group_kafka_key -%}
+            {%- for placeholder in group_kafka_key | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+                {%- if (placeholder | snake) not in second_msg_declared_params %}_{{ placeholder | snake }} = shared_key_value, {% endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+        data = data2
+        {%- for attrname, attribute in second_msg.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+            , _{{ attrname }} = ''
+        {%- endfor -%}
+    )
+    kafka_producer.flush(timeout=5.0)
+
+    # Collect keys from both messages
+    collected_keys = []
+    timeout = time.time() + 20
+    while len(collected_keys) < 2 and time.time() < timeout:
+        msg = consumer.poll(1.0)
+        if msg is None or msg.error():
+            continue
+        cloudevent = parse_cloudevent(msg)
+        if cloudevent['type'] in ["{{ first_msg_id }}", "{{ second_msg_id }}"]:
+            key = msg.key().decode('utf-8') if msg.key() else None
+            collected_keys.append(key)
+
+    assert len(collected_keys) == 2, f"Expected 2 messages but received {len(collected_keys)}"
+    assert collected_keys[0] == collected_keys[1], \
+        f"Expected same Kafka key for different event types but got '{collected_keys[0]}' and '{collected_keys[1]}'"
+    {%- set gkphs = group_kafka_key | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+    {%- if gkphs %}
+    expected_key = "{{ group_kafka_key }}".format({% for ph in gkphs %}{{ ph }}=shared_key_value{% if not loop.last %}, {% endif %}{% endfor %})
+    {%- else %}
+    expected_key = "{{ group_kafka_key }}"
+    {%- endif %}
+    assert collected_keys[0] == expected_key, \
+        f"Expected Kafka key '{expected_key}' but got '{collected_keys[0]}'"
+    consumer.close()
+{%- endif %}
 {%- endfor %}


### PR DESCRIPTION
## Problem

The generated Python Kafka producer's default \__key_mapper\ returned a composite \	ype:source-subject\ key regardless of what the xRegistry model declared. This broke partition affinity and ordering for entities whose Kafka key is explicitly configured (e.g. \{station_id}\ or \{identifier}\).

## Fix

The producer template now resolves the Kafka key from the xRegistry model:

1. **Message-level** \protocolmetadata.key.value\ (highest priority)
2. **Endpoint-level** \protocoloptions.options.key\
3. **Fallback** \	ype:source-subject\ composite (unchanged from before)

When the declared key is a URI template (e.g. \{station_id}\), the generated \send_*\ method gains the required parameters and resolves the template at runtime via \str.format()\. Callers can still override via the \key_mapper\ callback.

## Files changed

| File | Change |
|------|--------|
| \producer.py.jinja\ | Endpoint key lookup, message-level protocolmetadata check, key placeholder params, runtime resolution, updated \__key_mapper\ with fallback |
| \	est_producer.py.jinja\ | Key assertions per message + cross-event-type key test |
| \kafka.jinja.include\ | Replaced stale AMQP fields with proper Kafka fields |
| \	est/xreg/dwd.xreg.json\ | New test fixture with endpoint-level keys (\{station_id}\, \{identifier}\) |
| \	est/py/test_python.py\ | Added \	est_kafkaproducer_dwd_py\ |

## Verification

- DWD integration tests: 5/5 passed (3 CDC + 1 Weather + 1 cross-event-type)
- Contoso integration tests: 17/17 passed (backward compat, no declared keys)
- All 7 fixtures generate + py_compile cleanly
- Codegen tests: 2 passed, 3 skipped (pre-existing)