### PR TITLE
fix(jstruct): plumb avro_annotation through _process_jstruct_schemas

### DIFF
--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -256,7 +256,7 @@ class TemplateRenderer:
                 if len(jstruct_merged) == 1:
                     jstruct_merged = jstruct_merged[0]
                 
-                self._process_jstruct_schemas(jstruct_merged, project_data_dir, json_enabled)
+                self._process_jstruct_schemas(jstruct_merged, project_data_dir, json_enabled, avro_enabled)
             
             # Process Avro/converted schemas
             if avro_schemas:
@@ -321,13 +321,16 @@ class TemplateRenderer:
                 self.template_args, self.suppress_schema_output
             )
 
-    def _process_jstruct_schemas(self, jstruct_schema: JsonNode, project_data_dir: str, json_enabled: bool) -> None:
+    def _process_jstruct_schemas(self, jstruct_schema: JsonNode, project_data_dir: str, json_enabled: bool, avro_enabled: bool = False) -> None:
         """Process JSON Structure schemas using dedicated Avrotize converters.
         
         Args:
             jstruct_schema: The JSON Structure schema(s) to process
             project_data_dir: Directory for generated data classes
             json_enabled: Whether to enable JSON serialization annotations
+            avro_enabled: Whether to enable Avro serialization annotations (only honored
+                where avrotize's structure-to-language wrapper supports it; structuretojava
+                has no Avro emitter, so this flag is ignored for Java).
         """
         from avrotize.structuretocsharp import convert_structure_schema_to_csharp
         from avrotize.structuretojava import convert_structure_schema_to_java
@@ -343,15 +346,16 @@ class TemplateRenderer:
         if self.language == "py":
             convert_structure_schema_to_python(
                 jstruct_schema, project_data_dir, package_name=self.data_project_name,
-                dataclasses_json_annotation=json_enabled
+                dataclasses_json_annotation=json_enabled, avro_annotation=avro_enabled
             )
         elif self.language == "cs":
             convert_structure_schema_to_csharp(
                 jstruct_schema, project_data_dir, base_namespace=JinjaFilters.pascal(self.data_project_name),
-                pascal_properties=True, system_text_json_annotation=json_enabled
+                pascal_properties=True, system_text_json_annotation=json_enabled, avro_annotation=avro_enabled
             )
         elif self.language == "java":
-            # Java: use lowercase package name to match Maven artifact conventions
+            # Java: use lowercase package name to match Maven artifact conventions.
+            # avrotize.structuretojava has no Avro emitter, so avro_enabled is intentionally not forwarded here.
             java_package_name = self.data_project_name.lower().replace('-', '_')
             convert_structure_schema_to_java(
                 jstruct_schema, project_data_dir, package_name=java_package_name,
@@ -360,12 +364,12 @@ class TemplateRenderer:
         elif self.language == "ts":
             convert_structure_schema_to_typescript(
                 jstruct_schema, project_data_dir, package_name=self.data_project_name,
-                typedjson_annotation=json_enabled
+                typedjson_annotation=json_enabled, avro_annotation=avro_enabled
             )
         elif self.language == "go":
             convert_structure_schema_to_go(
                 jstruct_schema, project_data_dir, package_name=self.data_project_name,
-                json_annotation=json_enabled
+                json_annotation=json_enabled, avro_annotation=avro_enabled
             )
 
     def convert_proto_to_avro(self, schema_reference: str, schema_root: str) -> JsonNode:


### PR DESCRIPTION
## What

`_process_jstruct_schemas` now accepts `avro_enabled` and forwards `avro_annotation` to the avrotize `convert_structure_schema_to_{python,csharp,typescript,go}` wrappers. Java is intentionally not forwarded because `avrotize.structuretojava` has no Avro emitter at all (a separate upstream feature, not a bug fix).

## Why

When a source schema is JSON Structure (`jstruct`), the dedicated structure-to-language converters were never told to emit the Avro codec branch in the generated dataclasses, even when the user opted in via `--template-args avro-encoding=true`. As a result, generated Python/C#/TS/Go dataclasses for jstruct sources lacked:

- the `AvroType: ClassVar[avro.schema.Schema]` field,
- the `to_byte_array` `avro/binary` / `application/vnd.apache.avro+avro` branch using `DatumWriter` + `BinaryEncoder`,
- the matching `from_data` branch using `DatumReader` + `BinaryDecoder`.

This was not a 0.10.x regression — it has been the case since JSON Structure support landed in #124. The Avro→Python path (which goes through `convert_avro_schema_to_python`) was always correct.

## Verification

Regenerated `test/xreg/inkjet-jstruct.xreg.json` with `--template-args avro-encoding=true`:

- `import avro.schema` / `avro.io` emitted
- `AvroType: ClassVar[avro.schema.Schema] = avro.schema.parse(...)` emitted
- `to_byte_array` contains the `avro/binary` branch with `DatumWriter` + `BinaryEncoder`
- `from_data` contains the matching `DatumReader` + `BinaryDecoder` branch

Targeted test `test_kafkaproducer_inkjet_jstruct_py` passes locally (~136s).

## Upstream dependency

Depends on https://github.com/clemensv/avrotize/pull/313 so that `convert_structure_schema_to_python` accepts the `avro_annotation` kwarg. The C#/TS/Go avrotize wrappers already supported it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>