### PR TITLE
fix(ci): pin test-java-rabbitmq to RabbitMQ 3.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AMQP_BROKER: rabbitmq
+      # Pin to RabbitMQ 3.x: the templates use AMQP 1.0 v1 address format
+      # (amqp://host:port/queueName) which is only supported by the legacy
+      # rabbitmq_amqp1_0 plugin in 3.x. RabbitMQ 4.x rewrote the AMQP 1.0
+      # implementation and only accepts v2 addresses (/queues/<name>,
+      # /exchanges/<name>/<key>) -- enabling v1 addressing under 4.x would
+      # require updating the generated client templates to emit v2 addresses.
+      RABBITMQ_VERSION: "3"
     steps:
     - name: Checkout code
       uses: actions/checkout@v6


### PR DESCRIPTION
RabbitMQ 4.x's AMQP 1.0 implementation only accepts v2 addresses (`/queues/<name>`, `/exchanges/<name>/<key>`). The generated client templates emit v1 addresses (`amqp://host:port/queueName`) which only the legacy `rabbitmq_amqp1_0` plugin in 3.x supports.

The `test-java-rabbitmq` job has been failing since it was added in e4306cb (Nov 17) because `RABBITMQ_VERSION` defaulted to `4`, producing log spam like:

`amqp-receiver-localhost ERROR Error receiving message from amqp://localhost:32796/exampleQueue: Attach refused: {amqp_address_v1_not_permitted, ...}`

This is a tactical fix; the proper follow-up is to update the AMQP producer/consumer templates (cs/java/py) to emit v2 addresses, then unpin.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>