### PR TITLE
chore(deps): bump Testcontainers.ActiveMq and Testcontainers.Azurite to 4.11.0

### DIFF
--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -35,8 +35,8 @@
       <PackageReference Include="System.Memory.Data" Version="10.0.5" />
       <PackageReference Include="System.Text.Json" Version="10.0.5" />
       <PackageReference Include="Testcontainers" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.ActiveMq" Version="3.10.0" />
-      <PackageReference Include="Testcontainers.Azurite" Version="3.10.0" />
+      <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
       <PackageReference Include="Testcontainers.Kafka" Version="4.11.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">


### PR DESCRIPTION
Aligns with Testcontainers and Testcontainers.Kafka already at 4.11.0 (#240). Supersedes #234 and #237 which were stuck on merge conflicts.