### PR TITLE
fix(templates): support RabbitMQ 4 AMQP v2 addresses in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,13 +124,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AMQP_BROKER: rabbitmq
-      # Pin to RabbitMQ 3.x: the templates use AMQP 1.0 v1 address format
-      # (amqp://host:port/queueName) which is only supported by the legacy
-      # rabbitmq_amqp1_0 plugin in 3.x. RabbitMQ 4.x rewrote the AMQP 1.0
-      # implementation and only accepts v2 addresses (/queues/<name>,
-      # /exchanges/<name>/<key>) -- enabling v1 addressing under 4.x would
-      # require updating the generated client templates to emit v2 addresses.
-      RABBITMQ_VERSION: "3"
     steps:
     - name: Checkout code
       uses: actions/checkout@v6

--- a/xrcg/templates/cs/amqpconsumer/test/AmqpConsumerTest.cs.jinja
+++ b/xrcg/templates/cs/amqpconsumer/test/AmqpConsumerTest.cs.jinja
@@ -8,6 +8,9 @@
 
 using System;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -107,6 +110,7 @@ namespace {{ project_name | pascal }}.Test
         public ArtemisContainer? ArtemisContainerInstance { get; protected set; }
         public IContainer? RabbitMqContainerInstance { get; protected set; }
         public Uri? BrokerUrl { get; protected set; }
+        public Uri? EndpointUri { get; protected set; }
         protected ILoggerFactory _loggerFactory;
         protected ILogger _logger;
 
@@ -121,6 +125,46 @@ namespace {{ project_name | pascal }}.Test
             {
                 return "exampleQueue";
             }
+        }
+
+        public virtual string QueueAddress
+        {
+            get
+            {
+                return QueueName;
+            }
+        }
+
+        protected async Task DeclareRabbitMqQueueAsync(string host, int managementPort)
+        {
+            using var httpClient = new HttpClient();
+            var authBytes = Encoding.ASCII.GetBytes("guest:guest");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+            var queueUri = new Uri($"http://{host}:{managementPort}/api/queues/%2F/{QueueName}");
+            Exception? lastException = null;
+
+            for (var attempt = 0; attempt < 30; attempt++)
+            {
+                try
+                {
+                    using var content = new StringContent("{\"auto_delete\":false,\"durable\":true,\"arguments\":{}}", Encoding.UTF8, "application/json");
+                    using var response = await httpClient.PutAsync(queueUri, content);
+                    if ((int)response.StatusCode == 201 || (int)response.StatusCode == 204)
+                    {
+                        return;
+                    }
+
+                    lastException = new InvalidOperationException($"RabbitMQ queue declaration returned {(int)response.StatusCode} {response.ReasonPhrase}");
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            throw new InvalidOperationException($"Timed out declaring RabbitMQ queue '{QueueName}'", lastException);
         }
 
         public AmqpBrokerFixture()
@@ -161,6 +205,7 @@ namespace {{ project_name | pascal }}.Test
                 await ArtemisContainerInstance.StartAsync();
                 _logger.LogDebug("Artemis container started.");
                 BrokerUrl = new UriBuilder(ArtemisContainerInstance.GetBrokerAddress()){ Scheme = "amqp"}.Uri;
+                EndpointUri = new Uri(BrokerUrl, QueueName);
                 _logger.LogDebug($"Artemis broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -217,6 +262,7 @@ namespace {{ project_name | pascal }}.Test
                 var host = RabbitMqContainerInstance.Hostname;
                 var port = RabbitMqContainerInstance.GetMappedPublicPort(5672);
                 BrokerUrl = new Uri($"amqp://{host}:{port}");
+                EndpointUri = new Uri(BrokerUrl, QueueName);
                 _logger.LogDebug($"RabbitMQ 3.x broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -248,6 +294,14 @@ namespace {{ project_name | pascal }}.Test
     // Fixture for RabbitMQ 4.0+ (native AMQP 1.0 support)
     public class RabbitMq4Fixture : AmqpBrokerFixture
     {
+        public override string QueueAddress
+        {
+            get
+            {
+                return $"/queues/{QueueName}";
+            }
+        }
+
         public override async Task InitializeAsync()
         {
             try
@@ -271,7 +325,10 @@ namespace {{ project_name | pascal }}.Test
                 
                 var host = RabbitMqContainerInstance.Hostname;
                 var port = RabbitMqContainerInstance.GetMappedPublicPort(5672);
+                var managementPort = RabbitMqContainerInstance.GetMappedPublicPort(15672);
+                await DeclareRabbitMqQueueAsync(host, managementPort);
                 BrokerUrl = new Uri($"amqp://{host}:{port}");
+                EndpointUri = new Uri($"amqp://{host}:{port}/queues/{QueueName}");
                 _logger.LogDebug($"RabbitMQ 4.0+ broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -347,7 +404,7 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var dispatcher = {{ class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
                     .WithLogger(_fixture.GetLoggerFactory())
                     .Build();
@@ -390,7 +447,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var sender = new SenderLink(session, "sender-link", "/" + _fixture.QueueName);
+                            var sender = new SenderLink(session, "sender-link", _fixture.QueueAddress);
                             try
                             {
                                 {%- if message_body_type != "byte[]" %}
@@ -485,7 +542,7 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var dispatcher = {{ class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
                     .WithLogger(_fixture.GetLoggerFactory())
                     .Build();
@@ -527,7 +584,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var sender = new SenderLink(session, "test-sender", _fixture.QueueName);
+                            var sender = new SenderLink(session, "test-sender", _fixture.QueueAddress);
                             for (int i = 0; i < 5; i++)
                             {
                                 {%- if message_body_type == "byte[]" %}
@@ -607,7 +664,7 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var dispatcher = {{ class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
                     .WithLogger(_fixture.GetLoggerFactory())
                     .Build();
@@ -649,7 +706,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var sender = new SenderLink(session, "test-sender", _fixture.QueueName);
+                            var sender = new SenderLink(session, "test-sender", _fixture.QueueAddress);
                             for (int i = 0; i < 5; i++)
                             {
                                 {%- if message_body_type == "byte[]" %}

--- a/xrcg/templates/cs/amqpproducer/test/AmqpProducerTest.cs.jinja
+++ b/xrcg/templates/cs/amqpproducer/test/AmqpProducerTest.cs.jinja
@@ -9,6 +9,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -110,6 +113,7 @@ namespace {{ project_name | pascal }}.Test
         public ArtemisContainer? ArtemisContainerInstance { get; protected set; }
         public IContainer? RabbitMqContainerInstance { get; protected set; }
         public Uri? BrokerUrl { get; protected set; }
+        public Uri? EndpointUri { get; protected set; }
         protected ILoggerFactory _loggerFactory;
         protected ILogger _logger;
 
@@ -124,6 +128,46 @@ namespace {{ project_name | pascal }}.Test
             {
                 return "exampleQueue";
             }
+        }
+
+        public virtual string QueueAddress
+        {
+            get
+            {
+                return QueueName;
+            }
+        }
+
+        protected async Task DeclareRabbitMqQueueAsync(string host, int managementPort)
+        {
+            using var httpClient = new HttpClient();
+            var authBytes = Encoding.ASCII.GetBytes("guest:guest");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+            var queueUri = new Uri($"http://{host}:{managementPort}/api/queues/%2F/{QueueName}");
+            Exception? lastException = null;
+
+            for (var attempt = 0; attempt < 30; attempt++)
+            {
+                try
+                {
+                    using var content = new StringContent("{\"auto_delete\":false,\"durable\":true,\"arguments\":{}}", Encoding.UTF8, "application/json");
+                    using var response = await httpClient.PutAsync(queueUri, content);
+                    if ((int)response.StatusCode == 201 || (int)response.StatusCode == 204)
+                    {
+                        return;
+                    }
+
+                    lastException = new InvalidOperationException($"RabbitMQ queue declaration returned {(int)response.StatusCode} {response.ReasonPhrase}");
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            throw new InvalidOperationException($"Timed out declaring RabbitMQ queue '{QueueName}'", lastException);
         }
 
         public AmqpBrokerFixture()
@@ -164,6 +208,7 @@ namespace {{ project_name | pascal }}.Test
                 await ArtemisContainerInstance.StartAsync();
                 _logger.LogDebug("Artemis container started.");
                 BrokerUrl = new UriBuilder(ArtemisContainerInstance.GetBrokerAddress()){ Scheme = "amqp"}.Uri;
+                EndpointUri = new Uri(BrokerUrl, QueueName);
                 _logger.LogDebug($"Artemis broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -220,6 +265,7 @@ namespace {{ project_name | pascal }}.Test
                 var host = RabbitMqContainerInstance.Hostname;
                 var port = RabbitMqContainerInstance.GetMappedPublicPort(5672);
                 BrokerUrl = new Uri($"amqp://{host}:{port}");
+                EndpointUri = new Uri(BrokerUrl, QueueName);
                 _logger.LogDebug($"RabbitMQ 3.x broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -251,6 +297,14 @@ namespace {{ project_name | pascal }}.Test
     // Fixture for RabbitMQ 4.0+ (native AMQP 1.0 support)
     public class RabbitMq4Fixture : AmqpBrokerFixture
     {
+        public override string QueueAddress
+        {
+            get
+            {
+                return $"/queues/{QueueName}";
+            }
+        }
+
         public override async Task InitializeAsync()
         {
             try
@@ -274,7 +328,10 @@ namespace {{ project_name | pascal }}.Test
                 
                 var host = RabbitMqContainerInstance.Hostname;
                 var port = RabbitMqContainerInstance.GetMappedPublicPort(5672);
+                var managementPort = RabbitMqContainerInstance.GetMappedPublicPort(15672);
+                await DeclareRabbitMqQueueAsync(host, managementPort);
                 BrokerUrl = new Uri($"amqp://{host}:{port}");
+                EndpointUri = new Uri($"amqp://{host}:{port}/queues/{QueueName}");
                 _logger.LogDebug($"RabbitMQ 4.0+ broker URL: {BrokerUrl}");
             }
             catch (Exception ex)
@@ -348,9 +405,9 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var producer = {{ producer_class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
-                    .WithNode("/" + _fixture.QueueName)
+                    .WithNode(_fixture.QueueAddress)
                     .WithLogger(_fixture.GetLoggerFactory().CreateLogger<{{ producer_class_name }}>())
                     .Build();
                 try
@@ -367,7 +424,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var receiver = new ReceiverLink(session, "receiver-link", "/" + _fixture.QueueName);
+                            var receiver = new ReceiverLink(session, "receiver-link", _fixture.QueueAddress);
                             try
                             {
                                 // Start listening for 5 messages
@@ -502,7 +559,7 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var producer = {{ producer_class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
                     .WithLogger(_fixture.GetLoggerFactory().CreateLogger<{{ producer_class_name }}>())
                     .Build();
@@ -537,7 +594,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var receiver = new ReceiverLink(session, "test-receiver", _fixture.QueueName);
+                            var receiver = new ReceiverLink(session, "test-receiver", _fixture.QueueAddress);
                             var receivedMessage = await receiver.ReceiveAsync(TimeSpan.FromSeconds(10));
                             Assert.NotNull(receivedMessage);
                             receiver.Accept(receivedMessage);
@@ -592,7 +649,7 @@ namespace {{ project_name | pascal }}.Test
             {
                 var plainEndpointCredential = new PlainEndpointCredential("guest", "guest");
                 var producer = {{ producer_class_name }}.CreateBuilder()
-                    .WithEndpoint(new Uri(_fixture.BrokerUrl, _fixture.QueueName))
+                    .WithEndpoint(_fixture.EndpointUri)
                     .WithCredential(plainEndpointCredential)
                     .WithLogger(_fixture.GetLoggerFactory().CreateLogger<{{ producer_class_name }}>())
                     .Build();
@@ -627,7 +684,7 @@ namespace {{ project_name | pascal }}.Test
                         var session = new Session(connection);
                         try
                         {
-                            var receiver = new ReceiverLink(session, "test-receiver", _fixture.QueueName);
+                            var receiver = new ReceiverLink(session, "test-receiver", _fixture.QueueAddress);
                             var receivedMessage = await receiver.ReceiveAsync(TimeSpan.FromSeconds(10));
                             Assert.NotNull(receivedMessage);
                             receiver.Accept(receivedMessage);

--- a/xrcg/templates/java/amqpconsumer/src/test/java/{classdir}AmqpConsumerTest.java.jinja
+++ b/xrcg/templates/java/amqpconsumer/src/test/java/{classdir}AmqpConsumerTest.java.jinja
@@ -18,6 +18,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -43,6 +47,7 @@ public class {{ class_name | strip_namespace }} {
     private static GenericContainer<?> brokerContainer = createBrokerContainer();
     
     private URI brokerUrl;
+    private String queueAddress;
     
     private static GenericContainer<?> createBrokerContainer() {
         String broker = System.getenv().getOrDefault("AMQP_BROKER", "artemis");
@@ -81,8 +86,50 @@ public class {{ class_name | strip_namespace }} {
     public void setUp() throws Exception {
         String host = brokerContainer.getHost();
         Integer port = brokerContainer.getMappedPort(5672);
-        brokerUrl = new URI("amqp://" + host + ":" + port + "/" + QUEUE_NAME);
+        queueAddress = getQueueAddress(QUEUE_NAME);
+        if (isRabbitMq4()) {
+            declareRabbitMqQueue(QUEUE_NAME);
+        }
+        brokerUrl = new URI("amqp://" + host + ":" + port + (queueAddress.startsWith("/") ? queueAddress : "/" + queueAddress));
         logger.info("{} broker URL: {}", AMQP_BROKER, brokerUrl);
+    }
+
+    private boolean isRabbitMq4() {
+        return "rabbitmq".equalsIgnoreCase(AMQP_BROKER) && !"3".equals(System.getenv().getOrDefault("RABBITMQ_VERSION", "4"));
+    }
+
+    private String getQueueAddress(String queueName) {
+        return isRabbitMq4() ? "/queues/" + queueName : queueName;
+    }
+
+    private void declareRabbitMqQueue(String queueName) throws Exception {
+        String host = brokerContainer.getHost();
+        Integer managementPort = brokerContainer.getMappedPort(15672);
+        String credentials = Base64.getEncoder().encodeToString("guest:guest".getBytes(StandardCharsets.UTF_8));
+        HttpClient httpClient = HttpClient.newHttpClient();
+        URI queueUri = new URI("http://" + host + ":" + managementPort + "/api/queues/%2F/" + queueName);
+        Exception lastException = null;
+
+        for (int attempt = 0; attempt < 30; attempt++) {
+            try {
+                HttpRequest request = HttpRequest.newBuilder(queueUri)
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .header("Authorization", "Basic " + credentials)
+                    .header("Content-Type", "application/json")
+                    .PUT(HttpRequest.BodyPublishers.ofString("{\"auto_delete\":false,\"durable\":true,\"arguments\":{}}"))
+                    .build();
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() == 201 || response.statusCode() == 204) {
+                    return;
+                }
+                lastException = new IllegalStateException("RabbitMQ queue declaration returned " + response.statusCode() + ": " + response.body());
+            } catch (Exception ex) {
+                lastException = ex;
+            }
+            Thread.sleep(1000);
+        }
+
+        throw new IllegalStateException("Timed out declaring RabbitMQ queue " + queueName, lastException);
     }
     
     {%- for messagegroupid, messagegroup in messagegroups.items() %}
@@ -121,9 +168,11 @@ public class {{ class_name | strip_namespace }} {
     
     private void executeTest{{ messagename }}() throws Exception {
         PlainEndpointCredential credential = new PlainEndpointCredential("guest", "guest");
+        Map<String, String> options = new HashMap<>();
+        options.put("node", isRabbitMq4() ? "/" + queueAddress : queueAddress);
         {{ class_name }} consumer = {{ class_name }}.createConsumer(
             credential,
-            new HashMap<>(),
+            options,
             List.of(brokerUrl)
         );
         
@@ -163,7 +212,7 @@ public class {{ class_name | strip_namespace }} {
             connOptions.password("guest");
             
             connection = client.connect(brokerUrl.getHost(), brokerUrl.getPort(), connOptions);
-            Sender sender = connection.openSender(QUEUE_NAME);
+            Sender sender = connection.openSender(queueAddress);
             
             {%- if cloudEvents.isCloudEvent(message) %}
             // Create CloudEvent with test data

--- a/xrcg/templates/java/amqpproducer/src/test/java/{classdir}AmqpProducerTest.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/test/java/{classdir}AmqpProducerTest.java.jinja
@@ -30,6 +30,10 @@ import java.util.concurrent.CountDownLatch;
 {%- endif %}
 
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -96,6 +100,49 @@ public class {{ class_name | strip_namespace }} {
         brokerUrl = new URI(String.format("amqp://%s:%d", host, mappedPort));
         logger.info("{} broker container started at {}", AMQP_BROKER, brokerUrl);
     }
+
+    private boolean isRabbitMq4() {
+        return "rabbitmq".equalsIgnoreCase(AMQP_BROKER) && !"3".equals(System.getenv().getOrDefault("RABBITMQ_VERSION", "4"));
+    }
+
+    private String getQueueAddress(String queueName) {
+        return isRabbitMq4() ? "/queues/" + queueName : queueName;
+    }
+
+    private URI getEndpointUri(String queueName) throws Exception {
+        String queueAddress = getQueueAddress(queueName);
+        return new URI("amqp://" + brokerUrl.getHost() + ":" + brokerUrl.getPort() + (queueAddress.startsWith("/") ? queueAddress : "/" + queueAddress));
+    }
+
+    private void declareRabbitMqQueue(String queueName) throws Exception {
+        String host = brokerContainer.getHost();
+        Integer managementPort = brokerContainer.getMappedPort(15672);
+        String credentials = Base64.getEncoder().encodeToString("guest:guest".getBytes(StandardCharsets.UTF_8));
+        HttpClient httpClient = HttpClient.newHttpClient();
+        URI queueUri = new URI("http://" + host + ":" + managementPort + "/api/queues/%2F/" + queueName);
+        Exception lastException = null;
+
+        for (int attempt = 0; attempt < 30; attempt++) {
+            try {
+                HttpRequest request = HttpRequest.newBuilder(queueUri)
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .header("Authorization", "Basic " + credentials)
+                    .header("Content-Type", "application/json")
+                    .PUT(HttpRequest.BodyPublishers.ofString("{\"auto_delete\":false,\"durable\":true,\"arguments\":{}}"))
+                    .build();
+                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+                if (response.statusCode() == 201 || response.statusCode() == 204) {
+                    return;
+                }
+                lastException = new IllegalStateException("RabbitMQ queue declaration returned " + response.statusCode() + ": " + response.body());
+            } catch (Exception ex) {
+                lastException = ex;
+            }
+            Thread.sleep(1000);
+        }
+
+        throw new IllegalStateException("Timed out declaring RabbitMQ queue " + queueName, lastException);
+    }
     
 {%- for messagegroupid, messagegroup in messagegroups.items() %}
     {%- set pascal_group_name = messagegroupid | pascal %}
@@ -113,16 +160,20 @@ public class {{ class_name | strip_namespace }} {
         // Use unique queue name per test to avoid message accumulation
         String queueName = "test-queue-{{ messagename | lower }}";
         
+        if (isRabbitMq4()) {
+            declareRabbitMqQueue(queueName);
+        }
+        String queueAddress = getQueueAddress(queueName);
         PlainEndpointCredential credential = new PlainEndpointCredential("guest", "guest");
         Map<String, String> options = new HashMap<>();
-        options.put("node", queueName);
+        options.put("node", isRabbitMq4() ? "/" + queueAddress : queueAddress);
         {{ class_name }} producer = {{ class_name }}.createProducer(
             credential,
             {%- if cloudEvents.isCloudEvent(message) %}
             null, // No beforeSend callback for test
             {%- endif %}
             options,
-            new ArrayList<>(List.of(brokerUrl))
+            new ArrayList<>(List.of(getEndpointUri(queueName)))
         );
         
         List<Message<?>> messagesReceived = new ArrayList<>();
@@ -139,7 +190,7 @@ public class {{ class_name | strip_namespace }} {
                 connOptions.password("guest");
                 
                 connection = client.connect(brokerUrl.getHost(), brokerUrl.getPort(), connOptions);
-                Receiver receiver = connection.openReceiver(queueName);
+                Receiver receiver = connection.openReceiver(queueAddress);
                 
                 // Wait for 5 messages with timeout
                 int attempts = 0;

--- a/xrcg/templates/py/amqpconsumer/{testdir}test_dispatcher.py.jinja
+++ b/xrcg/templates/py/amqpconsumer/{testdir}test_dispatcher.py.jinja
@@ -5,13 +5,17 @@
 """
 Tests for {{ main_project_name }}
 """
+import base64
 import os
 import sys
 import asyncio
 import tempfile
+import urllib.error
+import urllib.request
 import pytest
 import time
 from typing import Optional
+from urllib.parse import quote_plus
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 from proton import Message
@@ -54,6 +58,47 @@ from {{ main_project_name|dotunderscore|lower }} import *
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
+
+
+
+def _rabbitmq_queue_address(queue_name: str) -> str:
+    return f"/queues/{queue_name}" if os.environ.get("RABBITMQ_VERSION", "4") != "3" else queue_name
+
+
+def _declare_rabbitmq_queue(host: str, mgmt_port: int, queue_name: str):
+    url = f"http://{host}:{mgmt_port}/api/queues/%2F/{queue_name}"
+    payload = b'{"auto_delete": false, "durable": true, "arguments": {}}'
+    auth = base64.b64encode(b"guest:guest").decode("ascii")
+    last_error = None
+    for _ in range(30):
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in (201, 204):
+                    return
+                last_error = RuntimeError(f"RabbitMQ queue declaration returned {response.status}")
+        except urllib.error.HTTPError as exc:
+            if exc.code in (201, 204):
+                return
+            last_error = exc
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out declaring RabbitMQ queue {queue_name}") from last_error
+
+
+def _connection_url(host: str, port: int, username: Optional[str] = None, password: Optional[str] = None) -> str:
+    if username and password:
+        return f"amqp://{quote_plus(username)}:{quote_plus(password)}@{host}:{port}"
+    return f"amqp://{host}:{port}"
 
 ARTEMIS_BROKER_XML = """<?xml version='1.0'?>
 <configuration xmlns="urn:activemq"
@@ -116,13 +161,16 @@ def amqp_broker():
         container.start()
         # Wait for RabbitMQ to be ready
         wait_for_logs(container, "Server startup complete", timeout=120)
+        host = container.get_container_host_ip()
+        if rabbitmq_version != "3":
+            _declare_rabbitmq_queue(host, int(container.get_exposed_port(15672)), "test-queue")
         
         yield {
-            "host": container.get_container_host_ip(),
+            "host": host,
             "port": container.get_exposed_port(5672),
             "username": "guest",
             "password": "guest",
-            "address": "test-queue"
+            "address": _rabbitmq_queue_address("test-queue")
         }
         
         container.stop()
@@ -208,7 +256,12 @@ def send_message_to_broker(broker_config: dict, message: Message, timeout: float
         message: The proton.Message to send
         timeout: Timeout in seconds
     """
-    url = f"{broker_config['host']}:{broker_config['port']}"
+    url = _connection_url(
+        broker_config['host'],
+        broker_config['port'],
+        broker_config.get('username'),
+        broker_config.get('password')
+    )
     sender = SimpleSender(url, broker_config['address'], 
                          username=broker_config.get('username'),
                          password=broker_config.get('password'))
@@ -335,7 +388,12 @@ class Test{{ class_name }}:
                     event.receiver.close()
                     event.connection.close()
         
-        connection_url = f"{artemis_container['host']}:{artemis_container['port']}"
+        connection_url = _connection_url(
+            artemis_container['host'],
+            artemis_container['port'],
+            artemis_container.get('username'),
+            artemis_container.get('password')
+        )
         receiver = SimpleReceiver(connection_url, artemis_container['address'],
                                  username=artemis_container.get('username'),
                                  password=artemis_container.get('password'))

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -10,6 +10,8 @@ import json
 import os
 import sys
 import tempfile
+import urllib.error
+import urllib.request
 from typing import Optional
 from urllib.parse import quote_plus
 
@@ -54,6 +56,41 @@ from {{ main_project_name|dotunderscore|lower }} import *
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
+
+
+
+def _rabbitmq_queue_address(queue_name: str) -> str:
+    return f"/queues/{queue_name}" if os.environ.get("RABBITMQ_VERSION", "4") != "3" else queue_name
+
+
+def _declare_rabbitmq_queue(host: str, mgmt_port: int, queue_name: str):
+    url = f"http://{host}:{mgmt_port}/api/queues/%2F/{queue_name}"
+    payload = b'{"auto_delete": false, "durable": true, "arguments": {}}'
+    auth = base64.b64encode(b"guest:guest").decode("ascii")
+    last_error = None
+    for _ in range(30):
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Basic {auth}",
+                "Content-Type": "application/json",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                if response.status in (201, 204):
+                    return
+                last_error = RuntimeError(f"RabbitMQ queue declaration returned {response.status}")
+        except urllib.error.HTTPError as exc:
+            if exc.code in (201, 204):
+                return
+            last_error = exc
+        except Exception as exc:
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Timed out declaring RabbitMQ queue {queue_name}") from last_error
 
 ARTEMIS_BROKER_XML = """<?xml version='1.0'?>
 <configuration xmlns="urn:activemq"
@@ -129,13 +166,16 @@ def amqp_broker():
         container.start()
         # Wait for RabbitMQ to be ready
         wait_for_logs(container, "Server startup complete", timeout=120)
+        host = container.get_container_host_ip()
+        if rabbitmq_version != "3":
+            _declare_rabbitmq_queue(host, int(container.get_exposed_port(15672)), "test-queue")
         
         yield {
-            "host": container.get_container_host_ip(),
+            "host": host,
             "port": int(container.get_exposed_port(5672)),
             "username": "guest",
             "password": "guest",
-            "address": "test-queue"
+            "address": _rabbitmq_queue_address("test-queue")
         }
         
         container.stop()


### PR DESCRIPTION
## Summary
- update C#, Java, and Python AMQP producer/consumer test fixtures to expose broker-specific queue link addresses
- predeclare RabbitMQ 4 queues through the management API before AMQP attaches
- remove the temporary RabbitMQ 3.x CI pin added as a workaround in #278

## Verification
- xrcg generate Java AMQP consumer/producer samples from test/xreg/lightbulb-amqp.xreg.json
- mvn -q -f tmp\\gen-java-p\\TestProject\\pom.xml test-compile
- mvn -q -f tmp\\gen-java-c\\TestProject\\pom.xml test-compile
- AMQP_BROKER=rabbitmq RABBITMQ_VERSION=4 pytest -v test/java/test_java.py::test_amqpproducer_lightbulb_amqp_java
- AMQP_BROKER=rabbitmq RABBITMQ_VERSION=4 pytest -v test/java/test_java.py::test_amqpconsumer_lightbulb_amqp_java
- default Artemis pytest -v test/java/test_java.py::test_amqpproducer_lightbulb_amqp_java
- generated Python AMQP consumer/producer samples and py_compile'd generated test files