### PR TITLE
fix(cs): Testcontainers 4.x compat (remove UntilPortIsAvailable, align versions)

### DIFF
--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -33,10 +33,10 @@
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
       <PackageReference Include="System.Memory.Data" Version="10.0.5" />
       <PackageReference Include="System.Text.Json" Version="10.0.5" />
-      <PackageReference Include="Testcontainers" Version="3.10.0" />
-      <PackageReference Include="Testcontainers.ActiveMq" Version="3.10.0" />
-      <PackageReference Include="Testcontainers.Azurite" Version="3.10.0" />
-      <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />
+      <PackageReference Include="Testcontainers" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.Kafka" Version="4.11.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/xrcg/dependencies/cs/net90/dependencies.csproj
+++ b/xrcg/dependencies/cs/net90/dependencies.csproj
@@ -34,9 +34,9 @@
       <PackageReference Include="System.Memory.Data" Version="10.0.6" />
       <PackageReference Include="System.Text.Json" Version="10.0.6" />
       <PackageReference Include="Testcontainers" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.ActiveMq" Version="3.10.0" />
+      <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
       <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.Kafka" Version="3.10.0" />
+      <PackageReference Include="Testcontainers.Kafka" Version="4.11.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
+++ b/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
@@ -85,7 +85,7 @@ namespace {{ project_name | pascal }}.Test
                     .WithImage("eclipse-mosquitto:2.0")
                     .WithBindMount(mosquittoConfigFilePath, "/mosquitto/config/mosquitto.conf")
                     .WithPortBinding(1883, true)
-                    .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(1883))
+                    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("mosquitto version .* running"))
                     .Build();
 
                 await MosquittoContainerInstance.StartAsync();

--- a/xrcg/templates/cs/sbconsumer/test/DispatcherTest.cs.jinja
+++ b/xrcg/templates/cs/sbconsumer/test/DispatcherTest.cs.jinja
@@ -95,7 +95,7 @@ namespace {{ project_name | pascal }}.Test
                     .WithEnvironment("MSSQL_SA_PASSWORD", "StrongPassword!1")
                     .WithNetwork(Network)
                     .WithNetworkAliases("sqledge")
-                    .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(1431))
+                    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("SQL Server is now ready for client connections"))
                     .WithOutputConsumer(outputConsumer)
                     .WithStartupCallback((container, ct) => Task.Delay(2000, ct)) // Extra settling time
                     .Build();

--- a/xrcg/templates/cs/sbproducer/test/ProducerTest.cs.jinja
+++ b/xrcg/templates/cs/sbproducer/test/ProducerTest.cs.jinja
@@ -98,7 +98,7 @@ namespace {{ project_name | pascal }}.Test
                     .WithEnvironment("MSSQL_SA_PASSWORD", "StrongPassword!1")
                     .WithNetwork(Network)
                     .WithNetworkAliases("sqledge")
-                    .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(1431))
+                    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("SQL Server is now ready for client connections"))
                     .WithOutputConsumer(outputConsumer)
                     .WithStartupCallback((container, ct) => Task.Delay(2000, ct)) // Extra settling time
                     .Build();


### PR DESCRIPTION
Fixes two regressions exposed by the recent Testcontainers 3.10 -> 4.11 dependabot bumps (#240, #275, #279).

**1. `UntilPortIsAvailable` removed in Testcontainers .NET 4.x**

The method was removed from `IWaitForContainerOS`. Replaced with `UntilMessageIsLogged` in three templates:
- `cs/sbproducer` + `cs/sbconsumer`: wait for `SQL Server is now ready for client connections`
- `cs/mqttclient`: wait for `mosquitto version .* running`

Failure: `error CS1061: 'IWaitForContainerOS' does not contain a definition for 'UntilPortIsAvailable'` (test-core).

**2. Mixed Testcontainers versions causing runtime ABI break**

`net80` and `net90` dependency manifests had base `Testcontainers` 4.11.0 mixed with `Testcontainers.ActiveMq`/`Testcontainers.Kafka` 3.10.0 (only `Testcontainers.Azurite` was aligned). `ContainerConfiguration..ctor` parameter list changed between majors, causing:

`System.MissingMethodException : Method not found: 'Void DotNet.Testcontainers.Configurations.ContainerConfiguration..ctor(...)'`

at runtime in 14 test-csharp test classes (eh*, mqtt*).

Aligned all four `Testcontainers*` packages to 4.11.0 across net80/net90/net100.