### PR TITLE
ci: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,42 @@
+name: Dependabot Auto-Merge
+
+# Automatically enables auto-merge (squash) on PRs opened by Dependabot.
+# GitHub completes the merge once all required status checks pass.
+# Falls back gracefully if no branch protection / required checks are configured:
+# auto-merge will simply complete as soon as the PR is mergeable + checks succeed.
+#
+# Scope: all updates EXCEPT major version bumps (those are left for manual review).
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, auto_merge_disabled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (non-major updates)
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+
+      - name: Comment on major updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-major' && github.event.action == 'opened'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr comment "$PR_URL" --body "Major version bump for **${{ steps.meta.outputs.dependency-names }}** (${{ steps.meta.outputs.previous-version }} → ${{ steps.meta.outputs.new-version }}). Skipping auto-merge; please review manually."


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml`: enables GitHub auto-merge (squash + delete branch) on every Dependabot PR.

- Triggers on `pull_request_target` so it runs with write permissions even for forks (Dependabot PRs come from the same repo, so this is safe).
- Uses `dependabot/fetch-metadata@v2` to classify the update.
- Skips `version-update:semver-major` and posts a comment instead, so major bumps still get human eyes (e.g., mypy 1.x→2.x, Spring Boot major).
- All other updates auto-merge once mergeable + checks green.
- `GITHUB_TOKEN` is sufficient; no PAT/secret required.

After this lands, the 30-PR backlog we just cleared shouldn't recur.