### PR TITLE
fix(loader): recognize spec-name 'basemessage' (alias of 'basemessageurl')

### DIFF
--- a/test/core/test_basemessage_resolution.py
+++ b/test/core/test_basemessage_resolution.py
@@ -614,5 +614,315 @@ class TestBasemessageResolution(unittest.TestCase):
         self.assertEqual(mqtt_msg["dataschemaurl"], "#/schemagroups/eventgroup/schemas/SensorReading")
 
 
+class TestBasemessageSpecAttributeName(unittest.TestCase):
+    """Tests that the loader honors the current spec attribute name
+    ``basemessage`` (xRegistry message spec 1.0-rc2+), in addition to the
+    legacy ``basemessageurl`` covered by ``TestBasemessageResolution``.
+
+    Regression coverage for https://github.com/xregistry/codegen/issues/283.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for file in os.listdir(self.temp_dir):
+            os.remove(os.path.join(self.temp_dir, file))
+        os.rmdir(self.temp_dir)
+
+    def _load(self, doc):
+        test_file = os.path.join(self.temp_dir, "test.json")
+        with open(test_file, 'w') as f:
+            json.dump(doc, f)
+        with patch('xrcg.generator.xregistry_loader.Model') as MockModel:
+            mock_model = Mock()
+            mock_model.groups = {
+                "messagegroups": {
+                    "resources": {
+                        "messages": {"singular": "message"}
+                    }
+                }
+            }
+            MockModel.return_value = mock_model
+            loader = XRegistryLoader()
+            _, result = loader.load(test_file)
+        return result
+
+    def test_basemessage_intra_group(self):
+        """``basemessage`` (spec name) is resolved like ``basemessageurl``
+        for a same-group reference."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "testgroup": {
+                    "messagegroupid": "testgroup",
+                    "messages": {
+                        "Base": {
+                            "messageid": "Base",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type":   {"value": "com.example.base"},
+                                "source": {"value": "/base/source"},
+                            },
+                            "datacontenttype": "application/json",
+                        },
+                        "Derived": {
+                            "messageid": "Derived",
+                            "basemessage": "/messagegroups/testgroup/messages/Base",
+                            "envelopemetadata": {
+                                "type": {"value": "com.example.derived"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        derived = result["messagegroups"]["testgroup"]["messages"]["Derived"]
+        # Overridden by derived
+        self.assertEqual(derived["envelopemetadata"]["type"]["value"], "com.example.derived")
+        # Inherited from base
+        self.assertEqual(derived["envelopemetadata"]["source"]["value"], "/base/source")
+        self.assertEqual(derived["envelope"], "CloudEvents/1.0")
+        self.assertEqual(derived["datacontenttype"], "application/json")
+        # Spec marker is removed after resolution
+        self.assertNotIn("basemessage", derived)
+        self.assertNotIn("basemessageurl", derived)
+
+    def test_basemessage_cross_messagegroup(self):
+        """The canonical spec example: a derived MQTT messagegroup whose
+        messages only set ``basemessage`` + ``protocol`` + ``protocoloptions``,
+        pointing across to a base CloudEvents-only group. Mirrors the
+        reproduction in issue #283."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "demo": {
+                    "messagegroupid": "demo",
+                    "messages": {
+                        "demo.Hello": {
+                            "messageid": "demo.Hello",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type":    {"value": "demo.Hello"},
+                                "subject": {"value": "{id}", "type": "uritemplate"},
+                            },
+                            "dataschemaformat": "JsonStructure/draft-02",
+                            "dataschemauri": "#/schemagroups/demo.jstruct/schemas/demo.Hello",
+                        },
+                    },
+                },
+                "demo.mqtt": {
+                    "messagegroupid": "demo.mqtt",
+                    "messages": {
+                        "demo.mqtt.Hello": {
+                            "messageid": "demo.mqtt.Hello",
+                            "basemessage": "/messagegroups/demo/messages/demo.Hello",
+                            "protocol": "MQTT/5.0",
+                            "protocoloptions": {
+                                "topic":  {"value": "demo/{id}/hello", "type": "uritemplate"},
+                                "qos":    1,
+                                "retain": True,
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        mqtt = result["messagegroups"]["demo.mqtt"]["messages"]["demo.mqtt.Hello"]
+        # Inherited envelope + schema metadata from cross-group base
+        self.assertEqual(mqtt["envelope"], "CloudEvents/1.0")
+        self.assertEqual(mqtt["envelopemetadata"]["type"]["value"], "demo.Hello")
+        self.assertEqual(mqtt["envelopemetadata"]["subject"]["value"], "{id}")
+        self.assertEqual(mqtt["dataschemaformat"], "JsonStructure/draft-02")
+        self.assertEqual(
+            mqtt["dataschemauri"],
+            "#/schemagroups/demo.jstruct/schemas/demo.Hello",
+        )
+        # Own protocol additions preserved
+        self.assertEqual(mqtt["protocol"], "MQTT/5.0")
+        self.assertEqual(mqtt["protocoloptions"]["topic"]["value"], "demo/{id}/hello")
+        self.assertEqual(mqtt["protocoloptions"]["qos"], 1)
+        self.assertTrue(mqtt["protocoloptions"]["retain"])
+        # Base group untouched
+        base = result["messagegroups"]["demo"]["messages"]["demo.Hello"]
+        self.assertNotIn("protocol", base)
+        self.assertNotIn("basemessage", mqtt)
+
+    def test_basemessage_transitive_chain(self):
+        """Multi-level ``basemessage`` chain across three messages."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "g": {
+                    "messagegroupid": "g",
+                    "messages": {
+                        "L1": {
+                            "messageid": "L1",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type":   {"value": "l1.type"},
+                                "source": {"value": "l1.source"},
+                            },
+                        },
+                        "L2": {
+                            "messageid": "L2",
+                            "basemessage": "/messagegroups/g/messages/L1",
+                            "envelopemetadata": {
+                                "type":    {"value": "l2.type"},
+                                "subject": {"value": "l2.subject"},
+                            },
+                        },
+                        "L3": {
+                            "messageid": "L3",
+                            "basemessage": "/messagegroups/g/messages/L2",
+                            "envelopemetadata": {
+                                "type": {"value": "l3.type"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        l3 = result["messagegroups"]["g"]["messages"]["L3"]
+        self.assertEqual(l3["envelope"], "CloudEvents/1.0")
+        self.assertEqual(l3["envelopemetadata"]["type"]["value"], "l3.type")       # own
+        self.assertEqual(l3["envelopemetadata"]["subject"]["value"], "l2.subject")  # from L2
+        self.assertEqual(l3["envelopemetadata"]["source"]["value"], "l1.source")    # from L1
+        self.assertNotIn("basemessage", l3)
+
+    def test_basemessage_circular_detection(self):
+        """Circular ``basemessage`` chain is detected and does not crash."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "g": {
+                    "messagegroupid": "g",
+                    "messages": {
+                        "A": {
+                            "messageid": "A",
+                            "basemessage": "/messagegroups/g/messages/B",
+                        },
+                        "B": {
+                            "messageid": "B",
+                            "basemessage": "/messagegroups/g/messages/A",
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        # Both messages remain in the document; cycle is logged, not raised.
+        self.assertIn("A", result["messagegroups"]["g"]["messages"])
+        self.assertIn("B", result["messagegroups"]["g"]["messages"])
+
+    def test_basemessage_missing_reference(self):
+        """Missing ``basemessage`` target is tolerated per spec (no error,
+        derived message kept with the marker stripped)."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "g": {
+                    "messagegroupid": "g",
+                    "messages": {
+                        "Derived": {
+                            "messageid": "Derived",
+                            "basemessage": "/messagegroups/g/messages/Missing",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type": {"value": "x"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        derived = result["messagegroups"]["g"]["messages"]["Derived"]
+        self.assertEqual(derived["envelope"], "CloudEvents/1.0")
+        self.assertEqual(derived["envelopemetadata"]["type"]["value"], "x")
+        self.assertNotIn("basemessage", derived)
+
+    def test_basemessage_scalar_overrides_object(self):
+        """Per spec: when the derived attribute is scalar and the base
+        attribute at the same key is an object, the scalar fully replaces
+        the (complex) base value."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "g": {
+                    "messagegroupid": "g",
+                    "messages": {
+                        "Base": {
+                            "messageid": "Base",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type": {
+                                    "value": "base.type",
+                                    "type":  "string",
+                                    "required": True,
+                                },
+                            },
+                        },
+                        "Derived": {
+                            "messageid": "Derived",
+                            "basemessage": "/messagegroups/g/messages/Base",
+                            "envelopemetadata": {
+                                "type": "literal-string",
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        derived = result["messagegroups"]["g"]["messages"]["Derived"]
+        # Scalar string fully replaces the complex object from the base.
+        self.assertEqual(derived["envelopemetadata"]["type"], "literal-string")
+
+    def test_basemessage_takes_precedence_over_basemessageurl(self):
+        """When a message specifies both spellings, the current-spec
+        ``basemessage`` wins."""
+        doc = {
+            "specversion": "1.0-rc2",
+            "messagegroups": {
+                "g": {
+                    "messagegroupid": "g",
+                    "messages": {
+                        "Real": {
+                            "messageid": "Real",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "source": {"value": "from-real"},
+                            },
+                        },
+                        "Stale": {
+                            "messageid": "Stale",
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "source": {"value": "from-stale"},
+                            },
+                        },
+                        "Derived": {
+                            "messageid": "Derived",
+                            "basemessage":    "/messagegroups/g/messages/Real",
+                            "basemessageurl": "/messagegroups/g/messages/Stale",
+                            "envelopemetadata": {
+                                "type": {"value": "d.type"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+        result = self._load(doc)
+        derived = result["messagegroups"]["g"]["messages"]["Derived"]
+        self.assertEqual(derived["envelopemetadata"]["source"]["value"], "from-real")
+        self.assertNotIn("basemessage", derived)
+        self.assertNotIn("basemessageurl", derived)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/xrcg/generator/xregistry_loader.py
+++ b/xrcg/generator/xregistry_loader.py
@@ -716,11 +716,42 @@ class ResourceResolver:
 
 
 class MessageResolver:
-    """Resolves basemessage references in message definitions."""
-    
+    """Resolves basemessage references in message definitions.
+
+    Two attribute names are honored:
+
+    * ``basemessage`` — the current xRegistry message spec (1.0-rc2+) name.
+      An XID pointing to another message definition, e.g.
+      ``/messagegroups/group1/messages/msg1``.
+    * ``basemessageurl`` — the legacy name used by earlier drafts and still
+      emitted by some tooling. Treated as a synonym for ``basemessage``.
+
+    If a message specifies both, ``basemessage`` takes precedence.
+    """
+
+    # Attribute names that may carry a base-message reference, in priority order.
+    _BASEMESSAGE_KEYS = ("basemessage", "basemessageurl")
+
     def __init__(self, loader: 'XRegistryLoader'):
         self.loader = loader
         self.logger = logging.getLogger(__name__ + ".MessageResolver")
+
+    def _get_basemessage_ref(self, message: Dict[str, Any]) -> Optional[str]:
+        """Return the base-message reference from a message, honoring both spec
+        names (``basemessage`` and the legacy ``basemessageurl``). Returns the
+        first non-empty value found, or None."""
+        for key in self._BASEMESSAGE_KEYS:
+            value = message.get(key)
+            if value:
+                return value
+        return None
+
+    def _strip_basemessage_keys(self, message: Dict[str, Any]) -> None:
+        """Remove all base-message reference attributes from a message dict
+        in place, so the resolved message no longer carries the marker."""
+        for key in self._BASEMESSAGE_KEYS:
+            if key in message:
+                del message[key]
     
     def _deep_merge(self, base: Dict[str, Any], overlay: Dict[str, Any]) -> Dict[str, Any]:
         """Deep merge two dictionaries with overlay shadowing base.
@@ -756,8 +787,9 @@ class MessageResolver:
         Returns:
             The fully resolved message with all base messages merged, or None if circular reference detected
         """
-        # Check for basemessageurl reference
-        base_ref = message.get('basemessageurl')
+        # Check for a base-message reference (current spec: ``basemessage``;
+        # legacy alias: ``basemessageurl``).
+        base_ref = self._get_basemessage_ref(message)
         if not base_ref:
             # No base message - return as-is
             return dict(message)
@@ -774,10 +806,9 @@ class MessageResolver:
         if not base_message:
             self.logger.warning(f"Base message not found: {base_ref}")
             # Per spec: "If the referenced message can not be found then an error MUST NOT be generated"
-            # Return current message without base, but remove basemessageurl
+            # Return current message without the base-message marker(s).
             result = dict(message)
-            if 'basemessageurl' in result:
-                del result['basemessageurl']
+            self._strip_basemessage_keys(result)
             return result
         
         # Recursively resolve the base message's chain
@@ -786,12 +817,11 @@ class MessageResolver:
             # Circular reference in base chain
             return None
         
-        # Remove basemessageurl from both before merging
+        # Remove base-message marker(s) from both sides before merging so the
+        # merged result is a clean, fully-resolved message.
         current = dict(message)
-        if 'basemessageurl' in current:
-            del current['basemessageurl']
-        if 'basemessageurl' in resolved_base:
-            del resolved_base['basemessageurl']
+        self._strip_basemessage_keys(current)
+        self._strip_basemessage_keys(resolved_base)
         
         # Merge: base first, then overlay with current message
         merged = self._deep_merge(resolved_base, current)
@@ -892,8 +922,10 @@ class MessageResolver:
             if not isinstance(message, dict):
                 continue
             
-            # Check if this message has a basemessageurl
-            if 'basemessageurl' not in message:
+            # Skip messages that have no base-message reference (under either
+            # the current spec name ``basemessage`` or the legacy alias
+            # ``basemessageurl``).
+            if not self._get_basemessage_ref(message):
                 continue
             
             self.logger.debug(f"Resolving basemessage for message: {message_id}")


### PR DESCRIPTION
Fixes #283.

## Problem

The xRegistry message spec (1.0-rc2+) defines the inheritance attribute as `basemessage` — an XID pointing at another message definition, e.g. `/messagegroups/demo/messages/demo.Hello`. The loader, however, only ever looked for the legacy `basemessageurl` attribute name. Manifests written against the current spec therefore received no inheritance resolution: derived messages were emitted without `envelope` / `envelopemetadata` / `dataschemaformat` / `dataschemauri` / `datacontenttype` / `description`, producing empty or silently-skipped generated classes.

The canonical use case in the spec — base CloudEvents-only group + derived MQTT-flavored group that only adds `protocol: MQTT/5.0` and per-message `protocoloptions` — was effectively unusable: users had to redeclare every inherited attribute on every derived message.

## Fix

`MessageResolver` now reads either attribute name and treats them as synonyms; `basemessage` wins when both are present. Both spellings are stripped after the chain is resolved so the merged message is clean. All other behavior is preserved:
- transitive resolution
- deep-merge of object/map attributes with scalar-overrides-object semantics
- circular-reference detection (logged, not raised)
- tolerant of dangling references per spec

## Tests

Added `TestBasemessageSpecAttributeName` with 7 new tests covering `basemessage`:
- intra-group reference
- cross-messagegroup reference (spec's canonical CloudEvents→MQTT example, mirrors the repro in #283)
- 3-level transitive chain
- circular reference detection
- missing target tolerated per spec
- scalar overrides complex base value
- precedence over `basemessageurl` when both are set

The 8 pre-existing `basemessageurl` tests still pass — full backward compatibility.