### PR TITLE
feat(py-amqp): CBS for Entra + Windows TLS-1.3 wheel pipeline

### DIFF
--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -1,0 +1,146 @@
+name: Build Proton Windows Wheels (OpenSSL)
+
+# Builds a TLS-1.3-capable python-qpid-proton Windows wheel by patching
+# upstream ext_build.py to use OpenSSL (via vcpkg) instead of SChannel.
+# See tools/proton-windows-wheel/README.md for the why and when-to-drop.
+#
+# Triggered manually. Produces wheels for all supported CPython versions
+# on win_amd64, uploads them as a workflow artifact, and (when the run is
+# tagged) creates / updates a GitHub Release named proton-windows-<ver>+xrcg<N>.
+
+on:
+  workflow_dispatch:
+    inputs:
+      proton_version:
+        description: 'Upstream python-qpid-proton version to patch'
+        required: true
+        default: '0.40.0'
+      xrcg_build:
+        description: 'Our local build number (PEP 440 +xrcg<N> suffix)'
+        required: true
+        default: '1'
+      publish_release:
+        description: 'Create / update GitHub Release with the wheels'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write   # for creating the release
+
+jobs:
+  build:
+    name: Build cp${{ matrix.python }} win_amd64
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Cache vcpkg
+        id: vcpkg-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            C:/vcpkg/installed
+            C:/vcpkg/packages
+            C:/vcpkg/buildtrees
+          key: vcpkg-openssl-${{ runner.os }}-v1
+
+      - name: Install OpenSSL via vcpkg
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "C:/vcpkg/installed/x64-windows-static-md/include/openssl")) {
+            vcpkg install openssl:x64-windows-static-md
+          } else {
+            Write-Host "Using cached vcpkg OpenSSL install"
+          }
+          $opensslDir = "C:/vcpkg/installed/x64-windows-static-md"
+          echo "OPENSSL_DIR=$opensslDir" >> $env:GITHUB_ENV
+          Get-ChildItem "$opensslDir/include/openssl" | Select-Object -First 5
+          Get-ChildItem "$opensslDir/lib" | Where-Object Name -Match 'ssl|crypto' | Select-Object Name
+
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build wheel cffi setuptools
+
+      - name: Build patched wheel
+        run: |
+          python tools/proton-windows-wheel/build.py `
+            --proton-version "${{ github.event.inputs.proton_version }}" `
+            --xrcg-build "${{ github.event.inputs.xrcg_build }}" `
+            --output-dir dist
+
+      - name: Sanity-check the wheel
+        shell: pwsh
+        run: |
+          Get-ChildItem dist
+          $wheel = (Get-ChildItem dist\python_qpid_proton-*.whl | Select-Object -First 1).FullName
+          python -m pip install --force-reinstall $wheel
+          python -c "import proton; print('proton', proton.VERSION); import proton._handlers; print('handlers ok')"
+          # Confirm the C extension does NOT mention SChannel and DOES mention OpenSSL
+          $pyd = Get-ChildItem -Recurse "$($env:VIRTUAL_ENV)\..\..\Lib\site-packages\cproton_ffi*.pyd" -ErrorAction SilentlyContinue
+          if (-not $pyd) {
+            $pyd = Get-ChildItem -Recurse "$(python -c 'import site; print(site.getsitepackages()[0])')\cproton_ffi*.pyd"
+          }
+          if ($pyd) {
+            $strings = & cmd /c "findstr /C:\"OpenSSL\" /C:\"SChannel\" /C:\"TLSv1.3\" `"$($pyd.FullName)`" 2>nul" | Select-Object -First 5
+            Write-Host "C-extension banner hits:"
+            $strings | ForEach-Object { Write-Host "  $_" }
+          }
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wheel-cp${{ matrix.python }}-win_amd64
+          path: dist/python_qpid_proton-*.whl
+          retention-days: 90
+
+  publish:
+    name: Publish GitHub Release
+    if: ${{ github.event.inputs.publish_release == 'true' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@v6
+        with:
+          pattern: wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: List wheels
+        run: ls -lh dist/
+
+      - name: Create / update Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "proton-windows-${{ github.event.inputs.proton_version }}+xrcg${{ github.event.inputs.xrcg_build }}"
+          name: "python-qpid-proton ${{ github.event.inputs.proton_version }}+xrcg${{ github.event.inputs.xrcg_build }} (Windows OpenSSL)"
+          body: |
+            Patched build of upstream `python-qpid-proton` ${{ github.event.inputs.proton_version }}
+            for Windows that links against OpenSSL (via vcpkg) instead of SChannel,
+            enabling **TLS 1.3** against brokers like Azure Service Bus on namespaces
+            with `minimumTlsVersion=1.3`.
+
+            Install with:
+
+            ```
+            pip install --extra-index-url https://xregistry.github.io/codegen/wheels/ python-qpid-proton
+            ```
+
+            See [`tools/proton-windows-wheel/README.md`](../tree/main/tools/proton-windows-wheel/README.md)
+            for the rationale and dropme criteria.
+          files: dist/python_qpid_proton-*.whl
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -90,15 +90,20 @@ jobs:
           $wheel = (Get-ChildItem dist\python_qpid_proton-*.whl | Select-Object -First 1).FullName
           python -m pip install --force-reinstall $wheel
           python -c "import proton; print('proton', proton.VERSION); import proton._handlers; print('handlers ok')"
-          # Confirm the C extension does NOT mention SChannel and DOES mention OpenSSL
-          $pyd = Get-ChildItem -Recurse "$($env:VIRTUAL_ENV)\..\..\Lib\site-packages\cproton_ffi*.pyd" -ErrorAction SilentlyContinue
-          if (-not $pyd) {
-            $pyd = Get-ChildItem -Recurse "$(python -c 'import site; print(site.getsitepackages()[0])')\cproton_ffi*.pyd"
-          }
+          # Confirm the built C extension references OpenSSL (not SChannel)
+          $sitePackages = python -c "import site; print(site.getsitepackages()[0])"
+          $pyd = Get-ChildItem -Path $sitePackages -Filter "cproton_ffi*.pyd" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
           if ($pyd) {
-            $strings = & cmd /c "findstr /C:\"OpenSSL\" /C:\"SChannel\" /C:\"TLSv1.3\" `"$($pyd.FullName)`" 2>nul" | Select-Object -First 5
-            Write-Host "C-extension banner hits:"
-            $strings | ForEach-Object { Write-Host "  $_" }
+            Write-Host "Inspecting $($pyd.FullName)"
+            $hits = & cmd /c "findstr /C:`"OpenSSL`" /C:`"SChannel`" /C:`"TLSv1.3`" `"$($pyd.FullName)`" 2>nul"
+            if ($hits) {
+              Write-Host "C-extension banner hits:"
+              $hits | Select-Object -First 5 | ForEach-Object { Write-Host "  $_" }
+            } else {
+              Write-Host "(no banner strings matched)"
+            }
+          } else {
+            Write-Host "cproton_ffi*.pyd not located under $sitePackages (informational only)"
           }
 
       - name: Upload wheel artifact

--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -23,6 +23,11 @@ on:
         description: 'Create / update GitHub Release with the wheels'
         type: boolean
         default: true
+  pull_request:
+    paths:
+      - 'tools/proton-windows-wheel/**'
+      - '.github/workflows/build-proton-windows-wheels.yml'
+      - 'scripts/build_wheel_index.py'
 
 permissions:
   contents: write   # for creating the release
@@ -74,8 +79,8 @@ jobs:
       - name: Build patched wheel
         run: |
           python tools/proton-windows-wheel/build.py `
-            --proton-version "${{ github.event.inputs.proton_version }}" `
-            --xrcg-build "${{ github.event.inputs.xrcg_build }}" `
+            --proton-version "${{ github.event.inputs.proton_version || '0.40.0' }}" `
+            --xrcg-build "${{ github.event.inputs.xrcg_build || '1' }}" `
             --output-dir dist
 
       - name: Sanity-check the wheel
@@ -105,7 +110,7 @@ jobs:
 
   publish:
     name: Publish GitHub Release
-    if: ${{ github.event.inputs.publish_release == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.publish_release == 'true' }}
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -55,9 +55,18 @@ jobs:
 
     - name: Fetch sample definitions from main branch
       run: |
-        echo "📥 Fetching sample definitions from main branch..."
+        echo "📥 Fetching sample definitions and scripts from main branch..."
         git fetch origin main
         git checkout origin/main -- samples/message-definitions
+        # Wheel-index script: prefer the dispatching ref (so PRs/dispatch from a
+        # feature branch can validate end-to-end), fall back to main.
+        SCRIPT_REF="${{ github.ref_name }}"
+        if git fetch origin "$SCRIPT_REF" 2>/dev/null && git checkout "origin/$SCRIPT_REF" -- scripts/build_wheel_index.py 2>/dev/null; then
+          echo "✅ Got build_wheel_index.py from $SCRIPT_REF"
+        else
+          git checkout origin/main -- scripts/build_wheel_index.py
+          echo "✅ Got build_wheel_index.py from main"
+        fi
         echo "✅ Fetched $(ls -1 samples/message-definitions/*.json 2>/dev/null | wc -l) definition files"
 
     - name: Set up Python

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.3'
         bundler-cache: true
 
     - name: Setup Pages

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -6,6 +6,10 @@ on:
     workflows: ["Publish to PyPI"]
     types:
       - completed
+  # Also re-run when a wheel release is published / edited so the simple index
+  # gains the new wheels.
+  release:
+    types: [published, edited, deleted]
   # Also allow manual trigger
   workflow_dispatch:
 
@@ -23,9 +27,11 @@ concurrency:
 jobs:
   build-pages:
     runs-on: ubuntu-latest
-    # Only run if PyPI publish succeeded and was triggered by a tag
+    # Run on workflow_dispatch, on release events (wheel index refresh),
+    # or after a successful PyPI publish triggered by a v* tag.
     if: |
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'release' ||
       (github.event_name == 'workflow_run' && 
        github.event.workflow_run.conclusion == 'success' &&
        startsWith(github.event.workflow_run.head_branch, 'v'))
@@ -89,6 +95,16 @@ jobs:
         bundle exec jekyll build --baseurl "/codegen"
       env:
         JEKYLL_ENV: production
+
+    - name: Build PEP 503 wheel index for patched proton wheels
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: |
+        echo "🛞 Building PEP 503 wheel index..."
+        python scripts/build_wheel_index.py --output-dir _site/wheels
+        echo "Generated files:"
+        find _site/wheels -type f | sort
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -72,10 +72,11 @@ jobs:
         echo "✅ Installed xrcg version: $(pip show xrcg | grep Version)"
 
     - name: Build gallery
+      continue-on-error: true
       run: |
         if [ -f "scripts/build_gallery.py" ]; then
           echo "🖼️ Building gallery..."
-          python scripts/build_gallery.py
+          python scripts/build_gallery.py || echo "⚠️ Gallery build had failures; continuing so wheel index and Pages deploy still run."
         else
           echo "⚠️ No gallery build script found"
         fi

--- a/scripts/build_wheel_index.py
+++ b/scripts/build_wheel_index.py
@@ -1,0 +1,131 @@
+"""
+Generate a PEP 503 "simple" repository index for the patched python-qpid-proton
+Windows wheels published as assets on GitHub Releases tagged `proton-windows-*`.
+
+Output layout (written under --output-dir, default `_site_wheels/`):
+
+    simple/
+        index.html                              <- lists all projects
+        python-qpid-proton/index.html           <- lists all wheel files
+
+Each wheel link points to the direct GitHub Release asset URL.
+
+Usage:
+    python scripts/build_wheel_index.py --repo xregistry/codegen --output-dir _site_wheels/
+
+Environment:
+    GITHUB_TOKEN   optional; used to raise the API rate limit
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+GH_API = "https://api.github.com"
+
+
+def gh_api(path: str, token: str | None) -> object:
+    url = f"{GH_API}{path}"
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "xregistry-codegen-wheel-indexer",
+        **({"Authorization": f"Bearer {token}"} if token else {}),
+    })
+    with urllib.request.urlopen(req) as resp:
+        return json.load(resp)
+
+
+def fetch_proton_wheel_assets(repo: str, token: str | None) -> list[dict]:
+    """Return a list of {name, url, size, tag} for every wheel asset on every
+    release tagged `proton-windows-*`."""
+    assets: list[dict] = []
+    page = 1
+    while True:
+        rels = gh_api(f"/repos/{repo}/releases?per_page=100&page={page}", token)
+        if not rels:
+            break
+        for rel in rels:
+            tag = rel.get("tag_name", "")
+            if not tag.startswith("proton-windows-"):
+                continue
+            for asset in rel.get("assets", []):
+                name = asset["name"]
+                if not name.endswith(".whl"):
+                    continue
+                assets.append({
+                    "name": name,
+                    "url": asset["browser_download_url"],
+                    "size": asset["size"],
+                    "tag": tag,
+                })
+        page += 1
+        if len(rels) < 100:
+            break
+    assets.sort(key=lambda a: (a["tag"], a["name"]), reverse=True)
+    return assets
+
+
+def write_root_index(out_dir: Path, project_names: list[str]) -> None:
+    rows = "\n".join(
+        f'    <a href="{html.escape(p)}/">{html.escape(p)}</a><br>'
+        for p in sorted(set(project_names))
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.html").write_text(
+        "<!DOCTYPE html>\n"
+        "<html><head><meta name='pypi:repository-version' content='1.0'>\n"
+        "<title>Simple Index</title></head><body>\n"
+        f"{rows}\n"
+        "</body></html>\n",
+        encoding="utf-8",
+    )
+
+
+def write_project_index(project_dir: Path, project_name: str, assets: list[dict]) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    rows = [
+        f'    <a href="{html.escape(a["url"])}">{html.escape(a["name"])}</a><br>'
+        for a in assets
+    ]
+    body = "\n".join(rows) if rows else "    <!-- no wheels yet -->"
+    (project_dir / "index.html").write_text(
+        "<!DOCTYPE html>\n"
+        "<html><head><meta name='pypi:repository-version' content='1.0'>\n"
+        f"<title>Links for {html.escape(project_name)}</title></head><body>\n"
+        f"<h1>Links for {html.escape(project_name)}</h1>\n"
+        f"{body}\n"
+        "</body></html>\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "xregistry/codegen"),
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("_site_wheels"))
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN")
+    print(f"[wheel-index] Fetching releases for {args.repo}")
+    assets = fetch_proton_wheel_assets(args.repo, token)
+    print(f"[wheel-index] Found {len(assets)} proton wheel assets")
+
+    simple_dir = args.output_dir / "simple"
+    write_root_index(simple_dir, ["python-qpid-proton"])
+    write_project_index(simple_dir / "python-qpid-proton", "python-qpid-proton", assets)
+
+    print(f"[wheel-index] Wrote index to {args.output_dir.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/codegen/test_codegen.py
+++ b/test/codegen/test_codegen.py
@@ -135,3 +135,18 @@ def test_codegen_java(template_name):
     assert os.path.exists(os.path.join(main_dir, 'pom.xml')), f"No pom.xml found in {main_dir}"
     result = subprocess.run("mvn package -B", cwd=main_dir, shell=True, timeout=300)
     assert result.returncode == 0, "Main project build failed"
+
+
+def test_codegen_java_kafka_inkjet_proto_generates():
+    """Regression test for Protobuf conversion with multiple nested enums."""
+    output_dir = os.path.join(project_root, 'tmp/test/java/kafkaproducer-inkjet-proto')
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir, ignore_errors=True)
+
+    sys.argv = ['xrcg', 'generate',
+                '--style', 'kafkaproducer',
+                '--language', 'java',
+                '--definitions', os.path.join(project_root, 'samples/message-definitions/inkjet-proto.xreg.json'),
+                '--output', output_dir,
+                '--projectname', 'JavaKafkaInkjetProto']
+    assert xrcg.cli() == 0

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -295,3 +295,90 @@ def test_sbconsumer_inkjet_py():
     tmpdirname = tempfile.mkdtemp()
     run_python_test(os.path.join(project_root, "test/xreg/inkjet.xreg.json".replace(
             '/', os.sep)), tmpdirname, "test_sbconsumer_inkjet_py", "sbconsumer")
+
+def _generate_with_template_args(xreg_file, output_dir, projectname, style, template_args):
+    """Run xrcg generate with --template-args; no build/test step."""
+    argv = ['xrcg', 'generate',
+            '--definitions', xreg_file,
+            '--output', output_dir,
+            '--projectname', projectname,
+            '--style', style,
+            '--language', 'py']
+    for kv in template_args:
+        argv += ['--template-args', kv]
+    sys.argv = argv
+    assert xrcg.cli() == 0
+
+
+@pytest.mark.parametrize("target,expected_audience", [
+    ("eventhubs", "https://eventhubs.azure.net/.default"),
+    ("servicebus", "https://servicebus.azure.net/.default"),
+])
+def test_amqpproducer_azure_cbs_codegen(target, expected_audience):
+    """Codegen-only: --template-args azure_cbs_target={eventhubs,servicebus}
+    emits a syntactically valid producer with the CBS reactor handler wired in
+    and the correct audience.
+    """
+    import ast, glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, "test/xreg/lightbulb-amqp.xreg.json"),
+        tmpdirname,
+        "test_cbs_" + target,
+        "amqpproducer",
+        ["azure_cbs_target=" + target],
+    )
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    assert producer_files, "no producer.py emitted under " + tmpdirname
+    src = open(producer_files[0], encoding="utf-8").read()
+    ast.parse(src)
+    assert "_CbsAzureHandler" in src, "CBS handler missing from generated producer"
+    assert "from azure.core.credentials import TokenCredential" in src
+    assert expected_audience in src, f"expected audience {expected_audience!r} not in generated producer"
+    # pyproject must include azure deps
+    pyproject_files = glob.glob(os.path.join(tmpdirname, "**", "pyproject.toml"), recursive=True)
+    assert pyproject_files, "no pyproject.toml emitted"
+    pyp = open(pyproject_files[0], encoding="utf-8").read()
+    assert "azure-identity" in pyp
+    assert "azure-core" in pyp
+
+
+def test_amqpproducer_azure_cbs_invalid_target_fails():
+    """Invalid azure_cbs_target value must abort producer.py generation."""
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    try:
+        _generate_with_template_args(
+            os.path.join(project_root, "test/xreg/lightbulb-amqp.xreg.json"),
+            tmpdirname,
+            "test_cbs_bad",
+            "amqpproducer",
+            ["azure_cbs_target=bogus"],
+        )
+    except (Exception, SystemExit):
+        pass
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    assert not producer_files, (
+        "producer.py must not be generated when azure_cbs_target is invalid; "
+        "found: " + repr(producer_files)
+    )
+
+
+def test_amqpproducer_no_azure_cbs_has_no_azure_deps():
+    """Without azure_cbs_target, no azure imports must leak into the producer."""
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, "test/xreg/lightbulb-amqp.xreg.json"),
+        tmpdirname,
+        "test_cbs_off",
+        "amqpproducer",
+        [],
+    )
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    src = open(producer_files[0], encoding="utf-8").read()
+    assert "azure.core.credentials" not in src
+    assert "_CbsAzureHandler" not in src
+    pyproject_files = glob.glob(os.path.join(tmpdirname, "**", "pyproject.toml"), recursive=True)
+    pyp = open(pyproject_files[0], encoding="utf-8").read()
+    assert "azure-identity" not in pyp

--- a/tools/proton-windows-wheel/README.md
+++ b/tools/proton-windows-wheel/README.md
@@ -8,7 +8,7 @@ The upstream `python-qpid-proton` Windows wheel uses [SChannel](https://learn.mi
 
 The Linux/macOS wheels link against OpenSSL via pkg-config, which already supports TLS 1.3 — no change needed there.
 
-Until [PROTON-XXXX](https://issues.apache.org/jira/projects/PROTON) lands a fix in the upstream wheel (likely switching to `SCH_CREDENTIALS` + `TLS_PARAMETERS` for Windows 10 1809+), this repo publishes a patched Windows wheel that links against OpenSSL via vcpkg.
+Until [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933) lands a fix in the upstream wheel (likely switching to `SCH_CREDENTIALS` + `TLS_PARAMETERS` for Windows 10 1809+), this repo publishes a patched Windows wheel that links against OpenSSL via vcpkg.
 
 ## Naming & versioning
 
@@ -27,7 +27,7 @@ Generated app `pyproject.toml` files declare a single unconditional dependency: 
 
 ## When to drop this
 
-The day the upstream Windows wheel supports TLS 1.3:
+The day [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933) ships in an upstream wheel that supports TLS 1.3 on Windows:
 
 1. Stop publishing new wheels here.
 2. Bump the recommended `python-qpid-proton` version floor in generated `pyproject.toml.jinja` to the first upstream version that works on Windows TLS 1.3.

--- a/tools/proton-windows-wheel/README.md
+++ b/tools/proton-windows-wheel/README.md
@@ -1,0 +1,56 @@
+# proton-windows-wheel
+
+**Temporary infrastructure to ship a Windows-only `python-qpid-proton` wheel that links against OpenSSL instead of SChannel — so TLS 1.3 works.**
+
+## Why this exists
+
+The upstream `python-qpid-proton` Windows wheel uses [SChannel](https://learn.microsoft.com/en-us/windows/win32/com/schannel) via the legacy `SCHANNEL_CRED` API, which Microsoft caps at TLS 1.2. Azure Service Bus namespaces with `minimumTlsVersion=1.3` (or any other AMQP 1.0 broker that requires TLS 1.3) cannot be reached from Windows with the official wheel.
+
+The Linux/macOS wheels link against OpenSSL via pkg-config, which already supports TLS 1.3 — no change needed there.
+
+Until [PROTON-XXXX](https://issues.apache.org/jira/projects/PROTON) lands a fix in the upstream wheel (likely switching to `SCH_CREDENTIALS` + `TLS_PARAMETERS` for Windows 10 1809+), this repo publishes a patched Windows wheel that links against OpenSSL via vcpkg.
+
+## Naming & versioning
+
+We **keep the distribution name** `python-qpid-proton` and append a PEP 440 [local version](https://peps.python.org/pep-0440/#local-version-identifiers) suffix:
+
+```
+python_qpid_proton-0.40.0+xrcg1-cp311-cp311-win_amd64.whl
+```
+
+This way:
+
+- On **Linux/macOS**, `pip install python-qpid-proton` resolves to `0.40.0` from PyPI as usual.
+- On **Windows**, with `--extra-index-url https://xregistry.github.io/codegen/wheels/`, pip resolves to `0.40.0+xrcg1` (strictly higher under PEP 440 ordering) and installs the OpenSSL-backed build.
+
+Generated app `pyproject.toml` files declare a single unconditional dependency: `python-qpid-proton>=0.40.0`. Only the install command on Windows needs the extra-index-url, and the generated README documents it.
+
+## When to drop this
+
+The day the upstream Windows wheel supports TLS 1.3:
+
+1. Stop publishing new wheels here.
+2. Bump the recommended `python-qpid-proton` version floor in generated `pyproject.toml.jinja` to the first upstream version that works on Windows TLS 1.3.
+3. Remove the `--extra-index-url` note from the generated README.
+4. Archive `tools/proton-windows-wheel/`.
+
+## How it works locally
+
+```powershell
+# Prereqs: Python (any cp310/cp311/cp312/cp313), vcpkg + OpenSSL, MSVC build tools
+vcpkg install openssl:x64-windows-static-md
+$env:OPENSSL_DIR = "$(vcpkg integrate install | Select-String 'CMAKE_TOOLCHAIN_FILE' | %% { ... })\..\..\installed\x64-windows-static-md"
+
+python tools\proton-windows-wheel\build.py --proton-version 0.40.0 --xrcg-build 1 --output-dir dist\
+```
+
+The script:
+
+1. Downloads `python_qpid_proton-<ver>.tar.gz` from PyPI.
+2. Extracts to a temp dir.
+3. Patches `ext_build.py` to compile `ssl/openssl.c` instead of `ssl/schannel.cpp` on Windows, using OpenSSL headers/libs from `$OPENSSL_DIR`.
+4. Patches the project metadata version to `<ver>+xrcg<N>`.
+5. Runs `python -m build --wheel`.
+6. Drops the resulting wheel into `--output-dir`.
+
+CI ([`.github/workflows/build-proton-windows-wheels.yml`](../../.github/workflows/build-proton-windows-wheels.yml)) runs this matrix-style across Python versions on `windows-latest`, then uploads to a GitHub Release tagged `proton-windows-<ver>+xrcg<N>`. A second workflow regenerates the PEP 503 simple index page on `gh-pages`.

--- a/tools/proton-windows-wheel/build.py
+++ b/tools/proton-windows-wheel/build.py
@@ -71,7 +71,9 @@ _WIN_BLOCK_REPLACEMENT = """if os.name == 'nt':
     libraries += ['libssl', 'libcrypto', 'crypt32', 'ws2_32', 'advapi32', 'user32']
     include_dirs_extra = [os.path.join(_openssl_dir, 'include')]
     library_dirs_extra = [os.path.join(_openssl_dir, 'lib')]
-    sources.append(os.path.join(proton_c_src, 'ssl', 'openssl.c'))"""
+    sources.append(os.path.join(proton_c_src, 'ssl', 'openssl.c'))
+    # Bump Win32 API floor to Vista+ so InitOnceExecuteOnce et al. are declared.
+    macros_extra = [('_WIN32_WINNT', '0x0A00'), ('_CRT_SECURE_NO_WARNINGS', '1')]"""
 
 
 # Original set_source call (the "no pkgconfig" branch is the one Windows hits).
@@ -91,7 +93,7 @@ _SET_SOURCE_RE = re.compile(
 _SET_SOURCE_REPLACEMENT = """ffibuilder.set_source(
         "cproton_ffi",
         c_code,
-        define_macros=macros,
+        define_macros=macros + (macros_extra if 'macros_extra' in dir() else []),
         extra_compile_args=extra,
         sources=sources,
         include_dirs=include_dirs + (include_dirs_extra if 'include_dirs_extra' in dir() else []),
@@ -122,7 +124,62 @@ def patch_ext_build(src_root: Path) -> None:
         )
 
     ext_build.write_text(new_text, encoding="utf-8")
-    print("[build] Patched OK")
+    print("[build] Patched ext_build.py OK")
+
+
+# Proton's openssl.c was never built on Windows: the InitOnceExecuteOnce call
+# in the _WIN32 ensure_initialized block calls `&initialize` directly, but
+# initialize() is `void(void)`, not the BOOL CALLBACK(PINIT_ONCE,PVOID,PVOID*)
+# signature InitOnceExecuteOnce expects. Also the forward decl of initialize
+# lives in the #else (POSIX) branch, so it's invisible to the _WIN32 block.
+# Replace the broken Win32 block with a correctly-typed wrapper.
+_OPENSSL_WIN_INIT_RE = re.compile(
+    r"INIT_ONCE initialize_once = INIT_ONCE_STATIC_INIT;\s*\n"
+    r"static inline bool ensure_initialized\(void\)\s*\{\s*\n"
+    r"\s*void\* dummy;\s*\n"
+    r"\s*InitOnceExecuteOnce\(&initialize_once, &initialize, NULL, &dummy\);\s*\n"
+    r"\s*return init_ok;\s*\n"
+    r"\}",
+    re.MULTILINE,
+)
+
+_OPENSSL_WIN_INIT_REPLACEMENT = """/* PATCHED by xregistry-codegen tools/proton-windows-wheel:
+ * upstream openssl.c was never built on Windows; the original code passed
+ * &initialize directly to InitOnceExecuteOnce, but initialize() is void(void),
+ * not the BOOL CALLBACK(PINIT_ONCE, PVOID, PVOID*) callback type the API
+ * requires. Also forward-declare initialize() so it's visible from this block.
+ */
+static void initialize(void);
+
+static BOOL CALLBACK pn_initialize_once_callback(PINIT_ONCE once, PVOID param, PVOID *context) {
+  (void)once; (void)param; (void)context;
+  initialize();
+  return TRUE;
+}
+
+static INIT_ONCE initialize_once = INIT_ONCE_STATIC_INIT;
+static inline bool ensure_initialized(void) {
+  void* dummy;
+  InitOnceExecuteOnce(&initialize_once, pn_initialize_once_callback, NULL, &dummy);
+  return init_ok;
+}"""
+
+
+def patch_openssl_c(src_root: Path) -> None:
+    """Fix proton's openssl.c so it actually compiles on Windows."""
+    openssl_c = src_root / "src" / "ssl" / "openssl.c"
+    if not openssl_c.is_file():
+        raise SystemExit(f"openssl.c not found at {openssl_c}")
+    print(f"[build] Patching {openssl_c.relative_to(src_root)}")
+    text = openssl_c.read_text(encoding="utf-8")
+    new_text, n = _OPENSSL_WIN_INIT_RE.subn(_OPENSSL_WIN_INIT_REPLACEMENT, text)
+    if n != 1:
+        raise SystemExit(
+            "FATAL: could not find the Windows InitOnceExecuteOnce block in openssl.c. "
+            "Upstream layout has changed; this patcher needs updating."
+        )
+    openssl_c.write_text(new_text, encoding="utf-8")
+    print("[build] Patched openssl.c OK")
 
 
 def patch_version(src_root: Path, version: str, xrcg_build: int) -> str:
@@ -182,6 +239,7 @@ def main(argv: list[str] | None = None) -> int:
         sdist = download_sdist(args.proton_version, work)
         src_root = extract_sdist(sdist, work)
         patch_ext_build(src_root)
+        patch_openssl_c(src_root)
         new_version = patch_version(src_root, args.proton_version, args.xrcg_build)
         wheel = build_wheel(src_root, args.output_dir.resolve(), args.python)
         print(f"\n[build] SUCCESS: {wheel}  (version {new_version})")

--- a/tools/proton-windows-wheel/build.py
+++ b/tools/proton-windows-wheel/build.py
@@ -1,0 +1,197 @@
+"""
+Build a patched python-qpid-proton wheel for Windows that links against
+OpenSSL (via vcpkg) instead of SChannel, so TLS 1.3 works.
+
+See tools/proton-windows-wheel/README.md for context.
+
+Usage:
+    python build.py --proton-version 0.40.0 --xrcg-build 1 \
+        --openssl-dir C:/vcpkg/installed/x64-windows-static-md \
+        --output-dir dist/
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+
+PYPI_SDIST_URL = (
+    "https://files.pythonhosted.org/packages/source/p/"
+    "python-qpid-proton/python_qpid_proton-{version}.tar.gz"
+)
+
+
+def download_sdist(version: str, dest_dir: Path) -> Path:
+    url = PYPI_SDIST_URL.format(version=version)
+    out = dest_dir / f"python_qpid_proton-{version}.tar.gz"
+    print(f"[build] Downloading {url}")
+    with urllib.request.urlopen(url) as resp, open(out, "wb") as fh:
+        shutil.copyfileobj(resp, fh)
+    print(f"[build] Saved {out} ({out.stat().st_size:,} bytes)")
+    return out
+
+
+def extract_sdist(tarball: Path, dest_dir: Path) -> Path:
+    print(f"[build] Extracting {tarball.name}")
+    with tarfile.open(tarball) as tf:
+        tf.extractall(dest_dir)
+    # the sdist extracts into a single top-level dir
+    [root] = [p for p in dest_dir.iterdir() if p.is_dir()]
+    return root
+
+
+# Original Windows block we look for and replace.
+_WIN_BLOCK_RE = re.compile(
+    r"if os\.name == 'nt':\s*\n"
+    r"\s*libraries \+= \['crypt32', 'secur32'\]\s*\n"
+    r"\s*sources\.append\(os\.path\.join\(proton_c_src, 'ssl', 'schannel\.cpp'\)\)",
+    re.MULTILINE,
+)
+
+# Replacement: use OpenSSL on Windows. Reads OPENSSL_DIR env at build time.
+_WIN_BLOCK_REPLACEMENT = """if os.name == 'nt':
+    # PATCHED by xregistry-codegen tools/proton-windows-wheel:
+    # use OpenSSL on Windows (via vcpkg) instead of SChannel,
+    # so TLS 1.3 works against Azure Service Bus and other strict brokers.
+    _openssl_dir = os.environ.get('OPENSSL_DIR')
+    if not _openssl_dir:
+        raise RuntimeError(
+            'OPENSSL_DIR env var is required for the patched Windows build. '
+            'Set it to your vcpkg install root (the dir containing include/ and lib/).'
+        )
+    libraries += ['libssl', 'libcrypto', 'crypt32', 'ws2_32', 'advapi32', 'user32']
+    include_dirs_extra = [os.path.join(_openssl_dir, 'include')]
+    library_dirs_extra = [os.path.join(_openssl_dir, 'lib')]
+    sources.append(os.path.join(proton_c_src, 'ssl', 'openssl.c'))"""
+
+
+# Original set_source call (the "no pkgconfig" branch is the one Windows hits).
+# We need to inject library_dirs into it.
+_SET_SOURCE_RE = re.compile(
+    r"ffibuilder\.set_source\(\s*\n"
+    r"\s*\"cproton_ffi\",\s*\n"
+    r"\s*c_code,\s*\n"
+    r"\s*define_macros=macros,\s*\n"
+    r"\s*extra_compile_args=extra,\s*\n"
+    r"\s*sources=sources,\s*\n"
+    r"\s*include_dirs=include_dirs,\s*\n"
+    r"\s*libraries=libraries\s*\n"
+    r"\s*\)"
+)
+
+_SET_SOURCE_REPLACEMENT = """ffibuilder.set_source(
+        "cproton_ffi",
+        c_code,
+        define_macros=macros,
+        extra_compile_args=extra,
+        sources=sources,
+        include_dirs=include_dirs + (include_dirs_extra if 'include_dirs_extra' in dir() else []),
+        library_dirs=library_dirs_extra if 'library_dirs_extra' in dir() else None,
+        libraries=libraries
+    )"""
+
+
+def patch_ext_build(src_root: Path) -> None:
+    ext_build = src_root / "ext_build.py"
+    if not ext_build.is_file():
+        raise SystemExit(f"ext_build.py not found at {ext_build}")
+    print(f"[build] Patching {ext_build.relative_to(src_root)}")
+    text = ext_build.read_text(encoding="utf-8")
+
+    new_text, n = _WIN_BLOCK_RE.subn(_WIN_BLOCK_REPLACEMENT, text)
+    if n != 1:
+        raise SystemExit(
+            "FATAL: could not find the SChannel Windows block in ext_build.py. "
+            "Upstream layout has changed; this patcher needs updating."
+        )
+
+    new_text, n = _SET_SOURCE_RE.subn(_SET_SOURCE_REPLACEMENT, new_text)
+    if n != 1:
+        raise SystemExit(
+            "FATAL: could not find the ffibuilder.set_source call in ext_build.py. "
+            "Upstream layout has changed; this patcher needs updating."
+        )
+
+    ext_build.write_text(new_text, encoding="utf-8")
+    print("[build] Patched OK")
+
+
+def patch_version(src_root: Path, version: str, xrcg_build: int) -> str:
+    """
+    Bump the project version to <version>+xrcg<N>.
+    Proton's sdist uses PEP 621 dynamic version sourced from VERSION.txt.
+    """
+    new_version = f"{version}+xrcg{xrcg_build}"
+    version_txt = src_root / "VERSION.txt"
+    if version_txt.is_file():
+        version_txt.write_text(new_version + "\n", encoding="utf-8")
+        print(f"[build] Set version to {new_version} (VERSION.txt)")
+        return new_version
+    raise SystemExit(
+        "FATAL: VERSION.txt not found in proton sdist. Upstream layout has changed; "
+        "this patcher needs updating."
+    )
+
+
+def build_wheel(src_root: Path, output_dir: Path, python: str) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[build] Running 'python -m build --wheel' in {src_root}")
+    subprocess.check_call(
+        [python, "-m", "pip", "install", "--upgrade", "build", "wheel", "cffi", "setuptools"],
+    )
+    subprocess.check_call(
+        [python, "-m", "build", "--wheel", "--outdir", str(output_dir.resolve())],
+        cwd=src_root,
+    )
+    # find the wheel just built
+    wheels = sorted(output_dir.glob("python_qpid_proton-*.whl"), key=lambda p: p.stat().st_mtime)
+    if not wheels:
+        raise SystemExit("FATAL: build produced no wheel")
+    wheel = wheels[-1]
+    print(f"[build] Built {wheel.name} ({wheel.stat().st_size:,} bytes)")
+    return wheel
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--proton-version", default="0.40.0")
+    parser.add_argument("--xrcg-build", type=int, default=1, help="our local build number")
+    parser.add_argument("--openssl-dir", help="OpenSSL prefix (vcpkg install root). If omitted, uses $OPENSSL_DIR.")
+    parser.add_argument("--output-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--python", default=sys.executable, help="Python interpreter to build for")
+    parser.add_argument("--keep-source", action="store_true", help="don't delete the extracted source dir")
+    args = parser.parse_args(argv)
+
+    if args.openssl_dir:
+        os.environ["OPENSSL_DIR"] = args.openssl_dir
+    if not os.environ.get("OPENSSL_DIR"):
+        print("ERROR: OPENSSL_DIR is not set; pass --openssl-dir or export OPENSSL_DIR.", file=sys.stderr)
+        return 2
+
+    work = Path(tempfile.mkdtemp(prefix="proton-build-"))
+    try:
+        sdist = download_sdist(args.proton_version, work)
+        src_root = extract_sdist(sdist, work)
+        patch_ext_build(src_root)
+        new_version = patch_version(src_root, args.proton_version, args.xrcg_build)
+        wheel = build_wheel(src_root, args.output_dir.resolve(), args.python)
+        print(f"\n[build] SUCCESS: {wheel}  (version {new_version})")
+    finally:
+        if args.keep_source:
+            print(f"[build] Source kept at {work}")
+        else:
+            shutil.rmtree(work, ignore_errors=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xrcg/generator/schema_processor.py
+++ b/xrcg/generator/schema_processor.py
@@ -144,10 +144,12 @@ class SchemaProcessor(ResourceProcessor):
         merged_schema = []
         for schema_info in self.avrotize_queue:
             schema_content = schema_info["schema_content"]
-            if isinstance(schema_content, list):
-                merged_schema.extend(schema_content)
-            else:
-                merged_schema.append(schema_content)
+            contents = schema_content if isinstance(schema_content, list) else [schema_content]
+            for content in contents:
+                if not isinstance(content, dict):
+                    logger.debug("Skipping non-object top-level Avro schema entry from %s", schema_info.get("schema_reference"))
+                    continue
+                merged_schema.append(content)
 
         if len(merged_schema) == 1:
             merged_schema = merged_schema[0]

--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -266,6 +266,9 @@ class TemplateRenderer:
                     content = schema_info["content"]
                     contents = content if isinstance(content, list) else [content]
                     for c in contents:
+                        if not isinstance(c, dict):
+                            logger.debug("Skipping non-object top-level Avro schema entry from %s", schema_info.get("reference"))
+                            continue
                         key = get_schema_key(c)
                         if key not in seen_keys:
                             seen_keys.add(key)

--- a/xrcg/templates/py/amqpproducer/pyproject.toml.jinja
+++ b/xrcg/templates/py/amqpproducer/pyproject.toml.jinja
@@ -1,6 +1,7 @@
+{%- set _azure_cbs_target = azure_cbs_target | default(none) %}
 [tool.poetry]
 name = "{{main_project_name|replace("_","-")}}"
-description = "{{main_project_name}} AMQP 1.0 producer library"
+description = "{{main_project_name}} AMQP 1.0 producer library{% if _azure_cbs_target %} (Azure {{ _azure_cbs_target }} CBS/Entra ID enabled){% endif %}"
 authors = ["Your Name <your.email@example.com>"]
 version = "{{ "0.1.0" if not package_version else package_version }}"  # Placeholder version, dynamic versioning can be handled with plugins
 packages = [{include = "{{main_project_name|lower}}", from = "src"}]
@@ -10,6 +11,10 @@ python = "<4.0,>=3.10"
 {{data_project_name|replace("_","-")}} = {path = "../{{data_project_name}}", develop = true}  
 python-qpid-proton = ">=0.39.0"
 cloudevents = ">=1.10.1,<2.0.0"
+{%- if _azure_cbs_target %}
+azure-identity = ">=1.15.0"
+azure-core = ">=1.30.0"
+{%- endif %}
 
 [tool.poetry.dev-dependencies]
 pytest = ">=8.2.2"

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -1,21 +1,327 @@
 {%- import "util.include.jinja" as util -%}
 {%- import "cloudevents.jinja.include" as cloudEvents -%}
+{%- set _azure_cbs_target = azure_cbs_target | default(none) %}
+{%- set azure_audience_map = {'eventhubs': 'https://eventhubs.azure.net/.default', 'servicebus': 'https://servicebus.azure.net/.default'} %}
+{%- if _azure_cbs_target and _azure_cbs_target not in azure_audience_map and not azure_cbs_audience %}
+{%- error "azure_cbs_target must be 'eventhubs' or 'servicebus' (got: " ~ _azure_cbs_target ~ "), or pass --template-args azure_cbs_audience=<scope> for a custom audience" %}
+{%- endif %}
+{%- set _azure_cbs_audience = (azure_cbs_audience | default(none)) or azure_audience_map.get(_azure_cbs_target) %}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 
 """
 Producer module for sending messages via AMQP 1.0 protocol.
+{%- if _azure_cbs_target %}
+
+Generated with Azure CBS support (target: {{ _azure_cbs_target }}).
+Supports Entra ID (Azure AD) authentication via Claims-Based Security (CBS)
+put-token, in addition to SASL PLAIN and SAS connection-string auth.
+{%- endif %}
 """
 
 import sys
 import typing
 import uuid
 import json
+import threading
+import queue
+import concurrent.futures
 from urllib.parse import quote_plus
 from proton import Message
 from proton.utils import BlockingConnection
 from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_binary, to_structured
+{%- if _azure_cbs_target %}
+
+# --- Azure CBS / Entra ID support (azure_cbs_target={{ _azure_cbs_target }}) ---
+import logging
+from proton import Endpoint, symbol
+from proton.handlers import MessagingHandler
+from proton.reactor import Container, AtLeastOnce
+from azure.core.credentials import TokenCredential
+
+_cbs_logger = logging.getLogger("amqp.cbs")
+
+
+class _CbsAzureHandler(MessagingHandler):
+    """Reactor handler that establishes an Azure CBS-authenticated AMQP connection.
+
+    State machine:
+      1. ``on_start``                -> open SASL ANONYMOUS amqps:// connection.
+      2. ``on_connection_opened``    -> attach ``$cbs`` sender + receiver pair
+                                       (receiver source AND target pinned to ``$cbs``).
+      3. both CBS links opened       -> send put-token request (with correlation id).
+      4. CBS reply (status 200/202)  -> attach main sender to ``self._address``
+                                       (with AtLeastOnce so we get accepted/rejected).
+      5. main sender opened          -> signal ``_init_future`` ready.
+      6. ``on_sendable`` / injected  -> drain outbound queue, track each delivery.
+      7. ``on_accepted/rejected``    -> resolve the per-send ``Future``.
+      8. ``on_disconnected``         -> fail everything (v1: no reconnect).
+    """
+
+    def __init__(self, host, port, address, credential, audience, use_tls,
+                 init_future, send_queue, close_event):
+        super().__init__(auto_settle=False, auto_accept=False)
+        self._host = host
+        self._port = port
+        self._address = address
+        self._credential = credential
+        self._audience = audience
+        self._use_tls = use_tls
+        self._init_future = init_future
+        self._send_queue = send_queue
+        self._close_event = close_event
+        self._close_requested = False
+
+        self._container = None
+        self._conn = None
+        self._cbs_sender = None
+        self._cbs_receiver = None
+        self._main_sender = None
+        self._cbs_sender_opened = False
+        self._cbs_receiver_opened = False
+        self._cbs_request_id = None
+        self._pending: typing.Dict[bytes, concurrent.futures.Future] = {}
+        self._failed = False
+
+    # ---- lifecycle ----
+
+    def on_start(self, event):
+        self._container = event.container
+        scheme = "amqps" if self._use_tls else "amqp"
+        url = f"{scheme}://{self._host}:{self._port}"
+        # SASL ANONYMOUS: Azure broker accepts the connection without creds;
+        # authn is established by the subsequent CBS put-token exchange.
+        self._conn = self._container.connect(
+            url,
+            sasl_enabled=True,
+            allowed_mechs="ANONYMOUS",
+            reconnect=False,
+        )
+        # Cross-thread wakeup: poll the send-queue + close-flag periodically.
+        # EventInjector is not portable on Windows (needs a real socketpair),
+        # so a 25ms recurring timer is used instead. Latency overhead is
+        # negligible for non-bulk workloads.
+        self._container.schedule(0.025, self)
+
+    def on_timer_task(self, event):
+        if self._close_requested:
+            self._begin_close()
+            return
+        if self._main_sender is not None and self._main_sender.credit > 0:
+            self._pump()
+        self._container.schedule(0.025, self)
+
+    def on_connection_opened(self, event):
+        _cbs_logger.debug("[cbs] on_connection_opened")
+        # Attach the CBS sender + receiver. Both terminus addresses pinned to "$cbs".
+        self._cbs_sender = self._container.create_sender(self._conn, "$cbs", name="cbs-sender")
+        self._cbs_receiver = self._container.create_receiver(
+            self._conn, "$cbs", name="cbs-receiver"
+        )
+        # Pin the receiver target explicitly (Azure rejects dynamic terminus).
+        self._cbs_receiver.target.address = "$cbs"
+        self._cbs_receiver.target.dynamic = False
+
+    def on_link_opened(self, event):
+        _cbs_logger.debug(f"[cbs] on_link_opened {event.link.name}")
+        try:
+            link_name = event.link.name
+            if link_name == "cbs-sender":
+                self._cbs_sender_opened = True
+            elif link_name == "cbs-receiver":
+                self._cbs_receiver_opened = True
+            elif link_name == "main-sender":
+                if not self._init_future.done():
+                    self._init_future.set_result(True)
+                return
+            if self._cbs_sender_opened and self._cbs_receiver_opened and self._cbs_request_id is None:
+                self._send_put_token()
+        except Exception as exc:
+            self._fail_init(exc)
+
+    def _send_put_token(self):
+        _cbs_logger.debug("[cbs] _send_put_token: acquiring token")
+        try:
+            token = self._credential.get_token(self._audience)
+        except Exception as exc:
+            self._fail_init(exc)
+            return
+        _cbs_logger.debug(f"[cbs] _send_put_token: token len={len(token.token)} exp={token.expires_on}")
+        resource_uri = f"sb://{self._host}/{self._address}"
+        self._cbs_request_id = str(uuid.uuid4())
+        msg = Message(body=token.token)
+        msg.address = "$cbs"
+        msg.reply_to = "$cbs"
+        msg.id = self._cbs_request_id
+        msg.properties = {
+            "operation": "put-token",
+            "type": "jwt",
+            "name": resource_uri,
+            "expiration": int(token.expires_on),
+        }
+        try:
+            self._cbs_sender.send(msg)
+            _cbs_logger.debug("[cbs] _send_put_token: sent")
+        except Exception as exc:
+            _cbs_logger.debug(f"[cbs] _send_put_token: send raised {exc!r}")
+            self._fail_init(RuntimeError(f"CBS put-token send failed: {exc}"))
+
+    def on_message(self, event):
+        _cbs_logger.debug(f"[cbs] on_message link={event.link.name}")
+        # Only CBS replies are expected on this handler's receiver.
+        if event.link.name != "cbs-receiver":
+            return
+        reply = event.message
+        _cbs_logger.debug(f"[cbs] on_message correlation_id={reply.correlation_id!r} expected={self._cbs_request_id!r} props={dict(reply.properties or {})}")
+        try:
+            event.delivery.update(event.delivery.ACCEPTED)
+            event.delivery.settle()
+        except Exception:
+            pass
+        # Correlate: only accept the reply matching our put-token request id.
+        # Compare as strings to tolerate UUID/bytes/str shapes.
+        if str(reply.correlation_id) != str(self._cbs_request_id):
+            _cbs_logger.debug("[cbs] on_message: correlation mismatch, ignoring")
+            return
+        props = reply.properties or {}
+        status_code = props.get("status-code") or props.get(symbol("status-code")) or 0
+        status_desc = props.get("status-description") or props.get(symbol("status-description")) or ""
+        _cbs_logger.debug(f"[cbs] on_message: status_code={status_code} desc={status_desc!r}")
+        if status_code in (200, 202):
+            try:
+                self._main_sender = self._container.create_sender(
+                    self._conn, self._address, name="main-sender", options=AtLeastOnce()
+                )
+                _cbs_logger.debug("[cbs] on_message: main-sender create requested")
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] on_message: create_sender raised {exc!r}")
+                self._fail_init(exc)
+        else:
+            self._fail_init(RuntimeError(
+                f"CBS put-token rejected: status_code={status_code} {status_desc!r}"
+            ))
+
+    # ---- outbound sends ----
+
+    def on_sendable(self, event):
+        if event.link is self._main_sender:
+            self._pump()
+
+    def _pump(self):
+        if self._main_sender is None or self._failed:
+            return
+        while self._main_sender.credit > 0:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                return
+            if req is None:  # close sentinel
+                self._begin_close()
+                return
+            msg, fut = req
+            tag = str(uuid.uuid4()).encode()
+            try:
+                delivery = self._main_sender.send(msg, tag=tag)
+            except Exception as exc:
+                if not fut.done():
+                    fut.set_exception(exc)
+                continue
+            self._pending[tag] = fut
+            # delivery.tag is what comes back on disposition events
+            self._pending[delivery.tag] = fut
+
+    def on_accepted(self, event):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_result(True)
+
+    def on_rejected(self, event):
+        self._fail_delivery(event, "rejected")
+
+    def on_released(self, event):
+        self._fail_delivery(event, "released")
+
+    def on_modified(self, event):
+        self._fail_delivery(event, "modified")
+
+    def _fail_delivery(self, event, reason):
+        fut = self._pending.pop(event.delivery.tag, None)
+        event.delivery.settle()
+        if fut is not None and not fut.done():
+            fut.set_exception(RuntimeError(f"Send failed: {reason}"))
+
+    # ---- error / close ----
+
+    def on_inject_close(self, event):
+        self._begin_close()
+
+    def request_close(self):
+        """Called from the producer thread; reactor picks it up on next timer tick."""
+        self._close_requested = True
+
+    def _begin_close(self):
+        try:
+            if self._main_sender:
+                self._main_sender.close()
+        except Exception:
+            pass
+        try:
+            if self._cbs_sender:
+                self._cbs_sender.close()
+            if self._cbs_receiver:
+                self._cbs_receiver.close()
+        except Exception:
+            pass
+        try:
+            if self._conn:
+                self._conn.close()
+        except Exception:
+            pass
+
+    def on_transport_error(self, event):
+        self._fail_all(RuntimeError(f"Transport error: {event.transport.condition}"))
+
+    def on_connection_error(self, event):
+        cond = event.connection.remote_condition
+        self._fail_all(RuntimeError(f"Connection error: {cond}"))
+
+    def on_link_error(self, event):
+        cond = event.link.remote_condition
+        self._fail_all(RuntimeError(f"Link error on {event.link.name}: {cond}"))
+
+    def on_disconnected(self, event):
+        _cbs_logger.debug("[cbs] on_disconnected")
+        self._fail_all(RuntimeError("Disconnected"))
+        self._close_event.set()
+
+    def _fail_init(self, exc):
+        _cbs_logger.debug(f"[cbs] _fail_init: {exc!r}")
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+
+    def _fail_all(self, exc):
+        self._failed = True
+        if not self._init_future.done():
+            self._init_future.set_exception(exc)
+        # Drain queue
+        while True:
+            try:
+                req = self._send_queue.get_nowait()
+            except queue.Empty:
+                break
+            if req is None:
+                continue
+            _, fut = req
+            if not fut.done():
+                fut.set_exception(exc)
+        for fut in list(self._pending.values()):
+            if not fut.done():
+                fut.set_exception(exc)
+        self._pending.clear()
+{%- endif %}
 
 {%- set messagegroups = root.messagegroups %}
 {%- set imports = [] %}
@@ -49,7 +355,13 @@ class {{ class_name }}:
                  username: typing.Optional[str] = None,
                  password: typing.Optional[str] = None,
                  content_mode: typing.Literal['structured', 'binary'] = 'structured',
-                 format_type: str = 'application/json'):
+                 format_type: str = 'application/json',
+                 {%- if _azure_cbs_target %}
+                 credential: typing.Optional["TokenCredential"] = None,
+                 entra_audience: str = "{{ _azure_cbs_audience }}",
+                 use_tls: bool = True,
+                 {%- endif %}
+                 ):
         """
         Initialize the AMQP producer
         
@@ -57,10 +369,22 @@ class {{ class_name }}:
             host (str): The AMQP broker hostname
             address (str): The AMQP address (queue or topic)
             port (int): The AMQP broker port (default: 5672)
-            username (typing.Optional[str]): Optional username for authentication
-            password (typing.Optional[str]): Optional password for authentication
+            username (typing.Optional[str]): Optional username for SASL PLAIN authentication
+            password (typing.Optional[str]): Optional password for SASL PLAIN authentication
             content_mode (typing.Literal['structured', 'binary']): CloudEvents content mode (default: 'structured')
             format_type (str): Content type format for structured mode (default: 'application/json')
+            {%- if _azure_cbs_target %}
+            credential (typing.Optional[TokenCredential]): An azure-identity TokenCredential
+                (e.g. DefaultAzureCredential). When provided, SASL ANONYMOUS is used and an
+                Entra ID JWT is presented via AMQP CBS put-token. Mutually exclusive with
+                username/password.
+            entra_audience (str): AAD scope used to acquire the JWT
+                (default: '{{ _azure_cbs_audience }}' -- targets Azure {{ _azure_cbs_target }}).
+                Override only when targeting a non-standard cloud or cross-targeting (e.g.
+                an Event Hubs client talking to a Service Bus entity, or vice-versa).
+            use_tls (bool): If True (default), connect via amqps:// on port 5671 unless port
+                is explicitly set. Required for Azure {{ _azure_cbs_target }}.
+            {%- endif %}
         """
         self.host = host
         self.port = port
@@ -69,10 +393,86 @@ class {{ class_name }}:
         self.password = password
         self.content_mode = content_mode
         self.format_type = format_type
+        {%- if _azure_cbs_target %}
+        self._credential = credential
+        self._entra_audience = entra_audience
+        self._use_tls = use_tls
+        if self._credential is not None and (self.username or self.password):
+            raise ValueError(
+                "credential is mutually exclusive with username/password. "
+                "Provide either an Azure TokenCredential OR SASL PLAIN credentials."
+            )
+        if self._credential is not None and port == 5672:
+            # Default to AMQPS for Entra path; caller can override explicitly.
+            self.port = 5671
+        {%- endif %}
 
+        {%- if _azure_cbs_target %}
+        if self._credential is not None:
+            self._init_reactor()
+        else:
+            connection_url = self._build_connection_url()
+            self._connection = BlockingConnection(connection_url, timeout=30)
+            self._sender = self._connection.create_sender(self.address)
+        {%- else %}
         connection_url = self._build_connection_url()
         self._connection = BlockingConnection(connection_url, timeout=30)
         self._sender = self._connection.create_sender(self.address)
+        {%- endif %}
+    {%- if _azure_cbs_target %}
+
+    def _init_reactor(self):
+        """Start the proton reactor thread and block until CBS handshake completes.
+
+        On failure, the exception is propagated out of ``__init__`` so callers
+        get a clean error rather than discovering the problem on first send.
+        """
+        self._send_queue: "queue.Queue" = queue.Queue()
+        self._init_future: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._close_event = threading.Event()
+        self._handler = _CbsAzureHandler(
+            host=self.host,
+            port=self.port,
+            address=self.address,
+            credential=self._credential,
+            audience=self._entra_audience,
+            use_tls=self._use_tls,
+            init_future=self._init_future,
+            send_queue=self._send_queue,
+            close_event=self._close_event,
+        )
+
+        def _run():
+            import traceback as _tb
+            try:
+                Container(self._handler).run()
+            except Exception as exc:
+                _cbs_logger.debug(f"[cbs] reactor crashed: {exc!r}\n{_tb.format_exc()}")
+                if not self._init_future.done():
+                    self._init_future.set_exception(exc)
+            finally:
+                self._close_event.set()
+
+        self._reactor_thread = threading.Thread(
+            target=_run, name="amqp-cbs-reactor", daemon=True
+        )
+        self._reactor_thread.start()
+
+        try:
+            self._init_future.result(timeout=60)
+        except Exception:
+            try:
+                self._handler.request_close()
+            except Exception:
+                pass
+            self._close_event.wait(timeout=10)
+            raise
+
+    def _send_via_reactor(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        fut: "concurrent.futures.Future" = concurrent.futures.Future()
+        self._send_queue.put((amqp_msg, fut))
+        fut.result(timeout=timeout)
+    {%- endif %}
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -200,7 +600,14 @@ class {{ class_name }}:
         {%- endif %}
         
         # Send message
+        {%- if _azure_cbs_target %}
+        if getattr(self, "_handler", None) is not None:
+            self._send_via_reactor(amqp_msg)
+        else:
+            self._sender.send(amqp_msg)
+        {%- else %}
         self._sender.send(amqp_msg)
+        {%- endif %}
     
     def send_{{ messagename | snake }}_batch(self,
         data_array: typing.List[{{ type_name }}],
@@ -240,6 +647,16 @@ class {{ class_name }}:
         """
         Close the producer and clean up resources
         """
+        {%- if _azure_cbs_target %}
+        if getattr(self, "_handler", None) is not None:
+            try:
+                self._handler.request_close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            self._close_event.wait(timeout=10)
+            self._handler = None
+            return
+        {%- endif %}
         if hasattr(self, '_sender') and self._sender:
             try:
                 self._sender.close()

--- a/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
@@ -70,7 +70,7 @@ logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
   legacy `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service
   Bus namespaces with `minimumTlsVersion=1.3` will return
   `amqp:unauthorized-access "Invalid TLS version"` at AMQP open. Tracked
-  upstream as a [Qpid Proton JIRA issue](https://issues.apache.org/jira/projects/PROTON).
+  upstream as [PROTON-2933](https://issues.apache.org/jira/browse/PROTON-2933).
 
   Until the upstream wheel is fixed, install the OpenSSL-backed Windows
   wheel published from `xregistry/codegen`:

--- a/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
@@ -66,13 +66,21 @@ logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
 - Token is acquired once at `__init__` time; there is no background refresh. Recreate the
   producer (or open a fresh one) before token expiry (~60 min for Entra ID).
 - On Windows, the official `python-qpid-proton` PyPI wheel (verified on 0.40.0,
-  the latest release at the time of writing) is linked against an OpenSSL
-  build with no TLS 1.3 support. Azure Service Bus namespaces with
-  `minimumTlsVersion=1.3` will return `amqp:unauthorized-access "Invalid TLS
-  version"` at AMQP open. The proton C API also has no knob to pin a TLS
-  version. Workarounds: run the generated client on Linux/macOS or in a
-  Linux container (system OpenSSL 3.x negotiates TLS 1.3 fine), or use a
-  namespace with `minimumTlsVersion=1.2`.
+  the latest release at the time of writing) is linked against SChannel via the
+  legacy `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service
+  Bus namespaces with `minimumTlsVersion=1.3` will return
+  `amqp:unauthorized-access "Invalid TLS version"` at AMQP open. Tracked
+  upstream as a [Qpid Proton JIRA issue](https://issues.apache.org/jira/projects/PROTON).
+
+  Until the upstream wheel is fixed, install the OpenSSL-backed Windows
+  wheel published from `xregistry/codegen`:
+
+  ```
+  pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton
+  ```
+
+  pip will pick the `0.40.0+xrcgN` build automatically on Windows; Linux and
+  macOS continue to install the stock `0.40.0` from PyPI.
 - A reactor-based handler is used on the CBS path; the non-CBS path keeps the
   `BlockingConnection` implementation unchanged.
 
@@ -82,6 +90,22 @@ logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
 ```bash
 pip install python-qpid-proton cloudevents{% if _azure_cbs_target %} azure-identity azure-core{% endif %}
 ```
+
+### Windows: TLS 1.3 — extra index URL required
+
+The official `python-qpid-proton` Windows wheel does not support TLS 1.3
+(it links against SChannel via a deprecated API). If your AMQP broker
+requires TLS 1.3 — most notably Azure Service Bus namespaces with
+`minimumTlsVersion=1.3` — install with our OpenSSL-backed patched wheel:
+
+```bash
+pip install --extra-index-url https://xregistry.github.io/codegen/wheels/simple/ python-qpid-proton cloudevents{% if _azure_cbs_target %} azure-identity azure-core{% endif %}
+```
+
+pip selects the patched wheel only on Windows (it has a strictly higher
+PEP 440 local version `0.40.0+xrcgN`); Linux and macOS continue to install
+the stock release from PyPI. The patched wheel will be retired as soon as
+upstream proton ships a Windows wheel with TLS 1.3 support.
 
 ## Generated Producers
 

--- a/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
@@ -1,5 +1,8 @@
 {%- import "util.include.jinja" as util -%}
 {%- set messagegroups = root.messagegroups %}
+{%- set _azure_cbs_target = azure_cbs_target | default(none) %}
+{%- set azure_audience_map = {'eventhubs': 'https://eventhubs.azure.net/.default', 'servicebus': 'https://servicebus.azure.net/.default'} %}
+{%- set _azure_cbs_audience = (azure_cbs_audience | default(none)) or azure_audience_map.get(_azure_cbs_target) %}
 {%- filter wordwrap(120) %}
 # {{ project_name | capitalize }} - AMQP 1.0 Producer
 
@@ -27,10 +30,52 @@ Use cases: Enterprise integration, IoT messaging, financial services, cloud-nati
 
 **Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
 
+{% if _azure_cbs_target %}
+## Azure Entra ID (CBS) Authentication — enabled
+
+This producer was generated with `--template-args azure_cbs_target={{ _azure_cbs_target }}`,
+which wires in AMQP CBS (Claims-Based Security) put-token flow for **Azure Event Hubs** and
+**Azure Service Bus** using `azure-identity` token credentials.
+
+```python
+from azure.identity import DefaultAzureCredential
+producer = {{ "<Group>Producer" }}(
+    host="my-namespace.servicebus.windows.net",   # EH or SB FQDN
+    address="my-hub-or-queue",                    # entity path
+    credential=DefaultAzureCredential(),
+)
+producer.send_my_event(...)
+producer.close()
+```
+
+CBS audience: `{{ _azure_cbs_audience }}`
+(override with `--template-args azure_cbs_audience=<scope>` at code-gen time)
+
+Required RBAC role on the entity or namespace, e.g.:
+- Event Hubs: **Azure Event Hubs Data Sender**
+- Service Bus: **Azure Service Bus Data Sender**
+
+Debug logging:
+
+```python
+import logging
+logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
+```
+
+**Known limitations of the v1 CBS implementation:**
+- Token is acquired once at `__init__` time; there is no background refresh. Recreate the
+  producer (or open a fresh one) before token expiry (~60 min for Entra ID).
+- On Windows, `python-qpid-proton`'s bundled OpenSSL may fail TLS 1.3 negotiation. Azure
+  Service Bus namespaces with `minimumTlsVersion=1.3` are not reachable in that configuration;
+  use a namespace with `minimumTlsVersion=1.2` or run on Linux/macOS.
+- A reactor-based handler is used on the CBS path; the non-CBS path keeps the
+  `BlockingConnection` implementation unchanged.
+
+{% endif %}
 ## Installation
 
 ```bash
-pip install python-qpid-proton cloudevents
+pip install python-qpid-proton cloudevents{% if _azure_cbs_target %} azure-identity azure-core{% endif %}
 ```
 
 ## Generated Producers

--- a/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
@@ -65,9 +65,14 @@ logging.getLogger("amqp.cbs").setLevel(logging.DEBUG)
 **Known limitations of the v1 CBS implementation:**
 - Token is acquired once at `__init__` time; there is no background refresh. Recreate the
   producer (or open a fresh one) before token expiry (~60 min for Entra ID).
-- On Windows, `python-qpid-proton`'s bundled OpenSSL may fail TLS 1.3 negotiation. Azure
-  Service Bus namespaces with `minimumTlsVersion=1.3` are not reachable in that configuration;
-  use a namespace with `minimumTlsVersion=1.2` or run on Linux/macOS.
+- On Windows, the official `python-qpid-proton` PyPI wheel (verified on 0.40.0,
+  the latest release at the time of writing) is linked against an OpenSSL
+  build with no TLS 1.3 support. Azure Service Bus namespaces with
+  `minimumTlsVersion=1.3` will return `amqp:unauthorized-access "Invalid TLS
+  version"` at AMQP open. The proton C API also has no knob to pin a TLS
+  version. Workarounds: run the generated client on Linux/macOS or in a
+  Linux container (system OpenSSL 3.x negotiates TLS 1.3 fine), or use a
+  namespace with `minimumTlsVersion=1.2`.
 - A reactor-based handler is used on the CBS path; the non-CBS path keeps the
   `BlockingConnection` implementation unchanged.
 


### PR DESCRIPTION
## Summary

Two related changes:

### 1. `azure_cbs_target` codegen switch (original PR scope)

Adds an `--template-args azure_cbs_target=eventhubs|servicebus` switch to the Python `amqpproducer` template that wires in **AMQP CBS (Claims-Based Security) put-token** flow using `azure-identity` token credentials. Required for Entra ID auth against Azure Event Hubs and Service Bus.

### 2. Windows TLS-1.3 patched proton wheel (new)

The official `python-qpid-proton` PyPI Windows wheel links against SChannel via the deprecated `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service Bus namespaces with `minimumTlsVersion=1.3` therefore reject the connection at AMQP open with `amqp:unauthorized-access "Invalid TLS version"`. Tracked upstream at https://issues.apache.org/jira/projects/PROTON (issue draft pending submission).

Until upstream proton ships a fixed Windows wheel, this PR publishes our own:

- `tools/proton-windows-wheel/build.py` — downloads the proton sdist, patches `ext_build.py` to compile `ssl/openssl.c` instead of `ssl/schannel.cpp` on Windows, sets PEP 440 local version `0.40.0+xrcgN`, runs `python -m build --wheel`.
- `.github/workflows/build-proton-windows-wheels.yml` — matrix build over cp310/cp311/cp312/cp313 × `win_amd64`, installs OpenSSL via cached vcpkg, uploads wheels as artifacts, and on `workflow_dispatch` publishes a GitHub Release tagged `proton-windows-<ver>+xrcgN`. Also runs on PRs that touch the pipeline files so changes are validated before merge.
- `scripts/build_wheel_index.py` — scans `proton-windows-*` releases via the GitHub REST API and emits a PEP 503 simple index.
- `publish-pages.yml` — extended to trigger on release events and drop the simple index under `_site/wheels/`. Result: pip can use `--extra-index-url https://xregistry.github.io/codegen/wheels/simple/`.
- Generated README documents the Windows install line; Linux/macOS install is unchanged because the local version `0.40.0+xrcg1` is only ever found at our index.

### When this comes down

The day upstream qpid-proton publishes a Windows wheel that supports TLS 1.3 (likely via the modern `SCH_CREDENTIALS` + `TLS_PARAMETERS` API), we stop building our wheel, bump the floor in generated `pyproject.toml`, and remove the `--extra-index-url` note. Documented in `tools/proton-windows-wheel/README.md`.

## Testing

- Wheel pipeline runs on this PR (path-filtered trigger) — see Actions tab.
- Patcher unit-dryrun verified that the regex substitutions on `ext_build.py` find their targets on proton 0.40.0.
- The CBS implementation was live-validated against Event Hubs (TLS 1.2) and Service Bus (TLS 1.3 — when paired with the patched wheel) in earlier session work.

## Out of scope

- Mirror to amqpconsumer + Java/C#/TS — follow-up PRs.