### PR TITLE
fix(py-amqp,py-mqtt): CE prefix + bytes body for spec-compliant wire format

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -382,3 +382,151 @@ def test_amqpproducer_no_azure_cbs_has_no_azure_deps():
     pyproject_files = glob.glob(os.path.join(tmpdirname, "**", "pyproject.toml"), recursive=True)
     pyp = open(pyproject_files[0], encoding="utf-8").read()
     assert "azure-identity" not in pyp
+
+
+def _generate_amqp_producer_src(xreg_relpath="test/xreg/lightbulb-amqp.xreg.json", template_args=None):
+    """Generate the Python AMQP producer for the given fixture and return
+    the contents of the generated producer.py as a string.
+    """
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, xreg_relpath.replace('/', os.sep)),
+        tmpdirname,
+        "test_amqp_introspect",
+        "amqpproducer",
+        template_args or [],
+    )
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    assert producer_files, "no producer.py emitted under " + tmpdirname
+    return open(producer_files[0], encoding="utf-8").read()
+
+
+def _generate_mqtt_client_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
+    """Generate the Python MQTT client for the given fixture and return the
+    contents of the generated client.py as a string.
+    """
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, xreg_relpath.replace('/', os.sep)),
+        tmpdirname,
+        "test_mqtt_introspect",
+        "mqttclient",
+        [],
+    )
+    client_files = glob.glob(os.path.join(tmpdirname, "**", "client.py"), recursive=True)
+    assert client_files, "no client.py emitted under " + tmpdirname
+    return open(client_files[0], encoding="utf-8").read()
+
+
+# ---------------------------------------------------------------------------
+# Wire-format regression tests for the Python producer/client templates.
+#
+# These guard against two specific regressions reported in production:
+#   1. The CloudEvents AMQP Protocol Binding v1.0.2 §3.1 mandates
+#      ``cloudEvents:`` as the application-properties prefix for CE
+#      attributes. The cloudevents-sdk's ``to_binary`` emits HTTP-style
+#      ``ce-`` headers; the producer MUST translate them. Assigning the
+#      raw dict to ``amqp_msg.properties`` produces wire-noncompliant
+#      messages that no CE-AMQP consumer will recognize.
+#   2. The generated dataclass ``to_byte_array("application/json")``
+#      returns ``str``; if passed straight to ``proton.Message(body=...)``
+#      proton emits an AMQP string section containing JSON (double-encoded
+#      on the wire). Same hazard for paho-mqtt PUBLISH payloads. The
+#      producer/client MUST coerce to ``bytes`` and proton MUST be told
+#      ``inferred=True`` so the body becomes an AMQP binary section.
+# ---------------------------------------------------------------------------
+
+def test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix():
+    """CloudEvents AMQP §3.1: application-properties prefix MUST be
+    ``cloudEvents:``. The legacy ``ce-`` HTTP-binding prefix MUST NOT
+    appear in any property key the producer puts on the wire.
+    """
+    # Use the CloudEvents-enveloped fixture so the CE code paths are emitted.
+    src = _generate_amqp_producer_src("test/xreg/lightbulb.xreg.json")
+    assert "cloudEvents:" in src, (
+        "producer.py must use the CloudEvents AMQP §3.1 'cloudEvents:' "
+        "prefix when mapping CE attributes onto application-properties"
+    )
+    assert "_ce_headers_to_amqp_properties" in src, (
+        "producer.py must translate cloudevents-sdk 'ce-' HTTP headers "
+        "into AMQP 'cloudEvents:' application-properties via a helper"
+    )
+    # Raw assignment of the cloudevents-sdk headers dict is the bug.
+    assert "amqp_msg.properties = headers" not in src, (
+        "producer.py must not assign the raw cloudevents-sdk headers "
+        "dict (which has 'ce-' prefixes) to amqp_msg.properties"
+    )
+
+
+def test_amqpproducer_body_is_bytes_with_inferred_true():
+    """The AMQP body MUST be a binary section. The producer must coerce
+    str payloads to bytes and instantiate ``Message`` with
+    ``inferred=True`` so proton emits an AMQP binary section instead of
+    an AMQP string section containing JSON.
+    """
+    # Use the CloudEvents-enveloped fixture so the CE binary/structured
+    # branches are emitted alongside the non-CE form.
+    src = _generate_amqp_producer_src("test/xreg/lightbulb.xreg.json")
+    # _serialize_payload coerces str -> bytes.
+    assert "payload.encode('utf-8')" in src or 'payload.encode("utf-8")' in src, (
+        "producer.py _serialize_payload must coerce str payloads to bytes"
+    )
+    # CE-enveloped messages must use the CE binary + structured forms.
+    assert "Message(body=body, inferred=True)" in src, (
+        "CloudEvent binary-mode send must build Message with inferred=True"
+    )
+    assert "Message(body=msg_body, inferred=True)" in src, (
+        "CloudEvent structured-mode send must build Message with inferred=True"
+    )
+    # Regression guards: the buggy forms must not reappear in CE paths.
+    for bad in (
+        "Message(body=body)\n",
+        "Message(body=msg_body)\n",
+    ):
+        assert bad not in src, (
+            "producer.py contains a Message(...) construction without "
+            "inferred=True (would emit AMQP string section for bytes): "
+            + bad.strip()
+        )
+
+
+def test_amqpproducer_non_cloudevent_body_is_bytes_with_inferred_true():
+    """The non-CloudEvent AMQP path must also build ``Message`` with
+    ``inferred=True`` so a bytes body becomes an AMQP binary section.
+    """
+    src = _generate_amqp_producer_src("test/xreg/lightbulb-amqp.xreg.json")
+    assert "Message(body=byte_data, inferred=True)" in src, (
+        "Non-CloudEvent send must build Message with inferred=True"
+    )
+    assert "Message(body=byte_data)\n" not in src, (
+        "Non-CloudEvent send must not build Message without inferred=True"
+    )
+
+
+def test_mqttclient_body_is_bytes_not_str():
+    """The MQTT PUBLISH payload MUST be bytes. ``to_byte_array`` returns
+    ``str`` for text content types; the client must coerce to bytes
+    before handing to cloudevents-sdk / paho-mqtt so receivers do not
+    have to double-decode JSON.
+    """
+    src = _generate_mqtt_client_src()
+    assert "byte_data = data.to_byte_array(content_type)" in src, (
+        "client.py must call to_byte_array on the dataclass"
+    )
+    # The coercion guard must be immediately downstream.
+    assert "isinstance(byte_data, str)" in src and "byte_data.encode('utf-8')" in src, (
+        "client.py must coerce byte_data str -> bytes before constructing "
+        "the CloudEvent (otherwise the wire body is a JSON string literal "
+        "containing JSON)"
+    )
+    # Final payload coercion guard for both content modes.
+    assert "isinstance(payload, dict)" in src, (
+        "client.py must coerce structured-mode dict payload to bytes "
+        "(otherwise paho-mqtt crashes on dict payloads)"
+    )
+    assert "isinstance(payload, str)" in src, (
+        "client.py must coerce str payload to bytes before publish so the "
+        "wire representation matches the declared content-type byte-for-byte"
+    )

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -530,3 +530,96 @@ def test_mqttclient_body_is_bytes_not_str():
         "client.py must coerce str payload to bytes before publish so the "
         "wire representation matches the declared content-type byte-for-byte"
     )
+
+
+def _generate_eh_producer_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
+    """Generate the Python Event Hubs producer for the given fixture."""
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, xreg_relpath.replace('/', os.sep)),
+        tmpdirname,
+        "test_eh_introspect",
+        "ehproducer",
+        [],
+    )
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    assert producer_files, "no producer.py emitted under " + tmpdirname
+    return open(producer_files[0], encoding="utf-8").read()
+
+
+def _generate_sb_producer_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
+    """Generate the Python Service Bus producer for the given fixture."""
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    _generate_with_template_args(
+        os.path.join(project_root, xreg_relpath.replace('/', os.sep)),
+        tmpdirname,
+        "test_sb_introspect",
+        "sbproducer",
+        [],
+    )
+    producer_files = glob.glob(os.path.join(tmpdirname, "**", "producer.py"), recursive=True)
+    assert producer_files, "no producer.py emitted under " + tmpdirname
+    return open(producer_files[0], encoding="utf-8").read()
+
+
+def test_ehproducer_emits_cloudevents_prefix_not_cloudevents_underscore():
+    """Event Hubs producer must use the CE-AMQP §3.1 ``cloudEvents:``
+    prefix on application-properties; the previous ``cloudEvents_``
+    (underscore) form is not recognized by spec-compliant CE consumers
+    such as azure-servicebus ``CloudEvent.from_message``.
+    """
+    src = _generate_eh_producer_src("test/xreg/lightbulb.xreg.json")
+    assert 'event_data.properties["cloudEvents:"+key[3:]]' in src, (
+        "ehproducer must map cloudevents-sdk 'ce-' headers to "
+        "'cloudEvents:' application-properties (CE-AMQP §3.1)"
+    )
+    assert "cloudEvents_" not in src, (
+        "ehproducer must not emit the non-spec 'cloudEvents_' "
+        "(underscore) prefix on application-properties"
+    )
+
+
+def test_ehproducer_body_is_bytes_not_str():
+    """Event Hubs producer must coerce JSON ``str`` payloads to bytes
+    before constructing ``EventData`` so the wire body is a binary AMQP
+    data section, not a string section containing escaped JSON.
+    """
+    src = _generate_eh_producer_src("test/xreg/lightbulb.xreg.json")
+    assert "byte_data = data.to_byte_array(content_type)" in src
+    assert "isinstance(byte_data, str)" in src and "byte_data.encode('utf-8')" in src, (
+        "ehproducer must coerce to_byte_array str result to bytes before "
+        "handing to the CloudEvent constructor"
+    )
+    assert "isinstance(body, str)" in src and "body.encode('utf-8')" in src, (
+        "ehproducer must coerce cloudevents-sdk body str to bytes before "
+        "constructing EventData (avoids AMQP string section + JSON double-encode)"
+    )
+
+
+def test_sbproducer_emits_cloudevents_prefix():
+    """Service Bus producer already maps to 'cloudEvents:' — guard the
+    mapping against regressions.
+    """
+    src = _generate_sb_producer_src("test/xreg/lightbulb.xreg.json")
+    assert 'message.application_properties["cloudEvents:"+key[3:]]' in src, (
+        "sbproducer must keep mapping 'ce-' headers to 'cloudEvents:' "
+        "application-properties (CE-AMQP §3.1)"
+    )
+
+
+def test_sbproducer_body_is_bytes_not_str():
+    """Service Bus producer must coerce JSON ``str`` payloads to bytes
+    before constructing ``ServiceBusMessage`` so the wire body is a
+    binary AMQP data section.
+    """
+    src = _generate_sb_producer_src("test/xreg/lightbulb.xreg.json")
+    assert "isinstance(byte_data, str)" in src and "byte_data.encode('utf-8')" in src, (
+        "sbproducer must coerce to_byte_array str result to bytes before "
+        "handing to the CloudEvent constructor"
+    )
+    assert "isinstance(body, str)" in src and "body.encode('utf-8')" in src, (
+        "sbproducer must coerce cloudevents-sdk body str to bytes before "
+        "constructing ServiceBusMessage"
+    )

--- a/test/ts/test_typescript.py
+++ b/test/ts/test_typescript.py
@@ -377,3 +377,102 @@ def test_egproducer_lightbulb_ts():
     tmpdirname = tempfile.mkdtemp()
     run_typescript_test(os.path.join(project_root, "test/xreg/lightbulb.xreg.json"),
                         tmpdirname, "TestProject", "egproducer")
+
+
+# ---------------------------------------------------------------------------
+# Wire-format introspection tests (codegen-only, no npm build required).
+#
+# Guard against the CloudEvents AMQP §3.1 prefix violation observed in the
+# TS amqpproducer / ehproducer / sbproducer templates: application-properties
+# carrying CE attributes were being emitted with the non-spec ``ce_*``
+# prefix (Kafka header convention) instead of the spec-mandated
+# ``cloudEvents:*`` prefix. Any compliant CE-AMQP consumer (azure-servicebus
+# ``CloudEvent.from_message``, Knative eventing, NATS adapters, …) will
+# fail to recognize ``ce_*`` keys as CloudEvents attributes.
+# ---------------------------------------------------------------------------
+
+def _generate_ts_producer_src(style, source_filename):
+    """Run xrcg for the given TS style against lightbulb.xreg.json and return
+    the contents of ``<style-output-dir>/src/<source_filename>`` as a string.
+    """
+    import glob
+    tmpdirname = tempfile.mkdtemp()
+    sys.argv = ['xrcg', 'generate',
+                '--definitions', os.path.join(project_root, 'test/xreg/lightbulb.xreg.json'),
+                '--output', tmpdirname,
+                '--projectname', 'TestProject',
+                '--style', style,
+                '--language', 'ts']
+    assert xrcg.cli() == 0
+    candidates = glob.glob(os.path.join(tmpdirname, '**', source_filename), recursive=True)
+    assert candidates, f'no {source_filename} emitted under {tmpdirname}'
+    return open(candidates[0], encoding='utf-8').read()
+
+
+def test_ts_amqpproducer_emits_cloudevents_prefix_not_ce_underscore():
+    """ts/amqpproducer must emit ``cloudEvents:*`` application-properties
+    keys (CE-AMQP §3.1) rather than the Kafka-style ``ce_*`` prefix that
+    was previously hardcoded in the template.
+    """
+    src = _generate_ts_producer_src('amqpproducer', 'producer.ts')
+    assert "'cloudEvents:specversion'" in src
+    assert "'cloudEvents:id'" in src
+    assert "'cloudEvents:type'" in src
+    assert "'cloudEvents:source'" in src
+    # Regression guards: the buggy spellings must not reappear.
+    for bad in ('ce_specversion', 'ce_id:', 'ce_type:', 'ce_source:',
+                'ce_subject', 'ce_time'):
+        assert bad not in src, (
+            f'ts/amqpproducer must not emit non-spec CE prefix: {bad!r}'
+        )
+
+
+def test_ts_amqpproducer_body_is_buffer_not_object():
+    """ts/amqpproducer must serialize the payload to a ``Buffer`` so rhea
+    emits an AMQP binary section. Passing a raw class instance / string
+    causes rhea to encode an AMQP map / string section, which produces
+    double-encoded wire payloads.
+    """
+    src = _generate_ts_producer_src('amqpproducer', 'producer.ts')
+    assert 'Buffer.from(' in src, (
+        'ts/amqpproducer must coerce payload bodies into Buffer instances'
+    )
+    # The raw-object body bug.
+    assert 'body: data,\n' not in src, (
+        'ts/amqpproducer must not pass raw `data` object as message body '
+        '(rhea would AMQP-encode it as a map)'
+    )
+
+
+def test_ts_ehproducer_emits_cloudevents_prefix_not_ce_underscore():
+    """ts/ehproducer must emit ``cloudEvents:*`` keys on EventData.properties
+    (which become AMQP application-properties on the wire).
+    """
+    src = _generate_ts_producer_src('ehproducer', 'producer.ts')
+    assert "'cloudEvents:specversion'" in src
+    assert "'cloudEvents:id'" in src
+    assert "'cloudEvents:type'" in src
+    assert "'cloudEvents:source'" in src
+    for bad in ("'ce_specversion'", "'ce_id'", "'ce_type'", "'ce_source'"):
+        assert bad not in src, (
+            f'ts/ehproducer must not emit non-spec CE prefix: {bad}'
+        )
+
+
+def test_ts_sbproducer_emits_cloudevents_prefix_not_ce_underscore():
+    """ts/sbproducer must emit ``cloudEvents:*`` keys on
+    ServiceBusMessage.applicationProperties.
+    """
+    src = _generate_ts_producer_src('sbproducer', 'producer.ts')
+    assert "'cloudEvents:specversion'" in src
+    assert "'cloudEvents:id'" in src
+    assert "'cloudEvents:type'" in src
+    assert "'cloudEvents:source'" in src
+    for bad in ("'ce_specversion'", "'ce_id'", "'ce_type'", "'ce_source'",
+                'ce_specversion:', 'ce_id:', 'ce_type:', 'ce_source:'):
+        assert bad not in src, (
+            f'ts/sbproducer must not emit non-spec CE prefix: {bad}'
+        )
+
+
+

--- a/xrcg/generator/xregistry_loader.py
+++ b/xrcg/generator/xregistry_loader.py
@@ -1475,15 +1475,43 @@ class XRegistryLoader:
                     filtered_messagegroups[group_id] = group_data
             filtered_doc["messagegroups"] = filtered_messagegroups
         
-        # Also filter schemagroups to match the filtered messagegroups
+        # Also filter schemagroups to keep only those referenced by the
+        # filtered messagegroups via dataschemauri (schemagroup IDs are
+        # independent of messagegroup IDs and must be resolved from refs).
         if isinstance(filtered_doc.get("schemagroups"), dict):
-            filtered_schemagroups = {}
-            for group_id, group_data in filtered_doc["schemagroups"].items():
-                if messagegroup_filter in group_id:
-                    filtered_schemagroups[group_id] = group_data
+            referenced_sg_ids = self._collect_referenced_schemagroup_ids(
+                filtered_doc.get("messagegroups", {}))
+            filtered_schemagroups = {
+                sg_id: sg_data
+                for sg_id, sg_data in filtered_doc["schemagroups"].items()
+                if not referenced_sg_ids or sg_id in referenced_sg_ids
+            }
             filtered_doc["schemagroups"] = filtered_schemagroups
         
         return filtered_doc
+
+    @staticmethod
+    def _collect_referenced_schemagroup_ids(messagegroups: Any) -> Set[str]:
+        """Walk messagegroups and collect schemagroup IDs referenced by any
+        message's dataschemauri (e.g. ``#/schemagroups/<id>/schemas/...``)."""
+        ids: Set[str] = set()
+        if not isinstance(messagegroups, dict):
+            return ids
+        for _, group in messagegroups.items():
+            if not isinstance(group, dict):
+                continue
+            messages = group.get("messages", {})
+            if not isinstance(messages, dict):
+                continue
+            for _, message in messages.items():
+                if not isinstance(message, dict):
+                    continue
+                uri = message.get("dataschemauri")
+                if isinstance(uri, str) and uri.startswith("#/schemagroups/"):
+                    parts = uri.split("/")
+                    if len(parts) > 2:
+                        ids.add(parts[2])
+        return ids
     
     def _apply_endpoint_filter(self, document: Dict[str, Any], 
                               endpoint_filter: str) -> Dict[str, Any]:
@@ -1538,13 +1566,18 @@ class XRegistryLoader:
                         filtered_messagegroups[group_id] = group_data
                 filtered_doc["messagegroups"] = filtered_messagegroups
             
-            # Step 4: Filter schemagroups to match the filtered messagegroups
-            if referenced_messagegroups and isinstance(filtered_doc.get("schemagroups"), dict):
-                filtered_schemagroups = {}
-                for group_id, group_data in filtered_doc["schemagroups"].items():
-                    if group_id in referenced_messagegroups:
-                        filtered_schemagroups[group_id] = group_data
-                filtered_doc["schemagroups"] = filtered_schemagroups
+            # Step 4: Filter schemagroups to keep only those referenced by
+            # the filtered messagegroups via dataschemauri. Schemagroup IDs
+            # are independent of messagegroup IDs (e.g. ``foo.jstruct`` vs
+            # ``foo.kafka``) and must be resolved from the actual refs.
+            if isinstance(filtered_doc.get("schemagroups"), dict):
+                referenced_sg_ids = self._collect_referenced_schemagroup_ids(
+                    filtered_doc.get("messagegroups", {}))
+                filtered_doc["schemagroups"] = {
+                    sg_id: sg_data
+                    for sg_id, sg_data in filtered_doc["schemagroups"].items()
+                    if not referenced_sg_ids or sg_id in referenced_sg_ids
+                }
         
         return filtered_doc
     

--- a/xrcg/generator/xregistry_loader.py
+++ b/xrcg/generator/xregistry_loader.py
@@ -1480,7 +1480,7 @@ class XRegistryLoader:
         # independent of messagegroup IDs and must be resolved from refs).
         if isinstance(filtered_doc.get("schemagroups"), dict):
             referenced_sg_ids = self._collect_referenced_schemagroup_ids(
-                filtered_doc.get("messagegroups", {}))
+                filtered_doc.get("messagegroups", {}), document)
             filtered_schemagroups = {
                 sg_id: sg_data
                 for sg_id, sg_data in filtered_doc["schemagroups"].items()
@@ -1491,26 +1491,64 @@ class XRegistryLoader:
         return filtered_doc
 
     @staticmethod
-    def _collect_referenced_schemagroup_ids(messagegroups: Any) -> Set[str]:
+    def _collect_referenced_schemagroup_ids(
+            messagegroups: Any,
+            full_document: Optional[Dict[str, Any]] = None) -> Set[str]:
         """Walk messagegroups and collect schemagroup IDs referenced by any
-        message's dataschemauri (e.g. ``#/schemagroups/<id>/schemas/...``)."""
+        message's ``dataschemauri`` (e.g. ``#/schemagroups/<id>/schemas/...``).
+
+        When a message inherits via ``basemessageurl`` from another
+        messagegroup, the base message is followed in ``full_document`` so
+        that schemagroups referenced only by the base are still kept.
+        """
         ids: Set[str] = set()
-        if not isinstance(messagegroups, dict):
-            return ids
-        for _, group in messagegroups.items():
-            if not isinstance(group, dict):
-                continue
-            messages = group.get("messages", {})
-            if not isinstance(messages, dict):
-                continue
-            for _, message in messages.items():
-                if not isinstance(message, dict):
+        visited: Set[str] = set()
+        full_mgs = (full_document or {}).get("messagegroups", {}) \
+            if isinstance(full_document, dict) else {}
+
+        def _record_uri(uri: Any) -> None:
+            if isinstance(uri, str) and uri.startswith("#/schemagroups/"):
+                parts = uri.split("/")
+                if len(parts) > 2:
+                    ids.add(parts[2])
+
+        def _resolve_base(base_url: Any) -> Optional[Dict[str, Any]]:
+            if not isinstance(base_url, str) or not isinstance(full_mgs, dict):
+                return None
+            # Accept forms like
+            #   /messagegroups/<mg>/messages/<msg>
+            #   #/messagegroups/<mg>/messages/<msg>
+            tokens = [t for t in base_url.split("/") if t and t != "#"]
+            if len(tokens) >= 4 and tokens[0] == "messagegroups" \
+                    and tokens[2] == "messages":
+                mg = full_mgs.get(tokens[1])
+                if isinstance(mg, dict):
+                    msg = mg.get("messages", {}).get(tokens[3])
+                    if isinstance(msg, dict):
+                        return msg
+            return None
+
+        def _visit(message: Dict[str, Any], depth: int = 0) -> None:
+            if depth > 16:
+                return
+            _record_uri(message.get("dataschemauri"))
+            base = message.get("basemessageurl") or message.get("basemessage")
+            if isinstance(base, str) and base not in visited:
+                visited.add(base)
+                resolved = _resolve_base(base)
+                if resolved is not None:
+                    _visit(resolved, depth + 1)
+
+        if isinstance(messagegroups, dict):
+            for _, group in messagegroups.items():
+                if not isinstance(group, dict):
                     continue
-                uri = message.get("dataschemauri")
-                if isinstance(uri, str) and uri.startswith("#/schemagroups/"):
-                    parts = uri.split("/")
-                    if len(parts) > 2:
-                        ids.add(parts[2])
+                messages = group.get("messages", {})
+                if not isinstance(messages, dict):
+                    continue
+                for _, message in messages.items():
+                    if isinstance(message, dict):
+                        _visit(message)
         return ids
     
     def _apply_endpoint_filter(self, document: Dict[str, Any], 
@@ -1572,7 +1610,7 @@ class XRegistryLoader:
             # ``foo.kafka``) and must be resolved from the actual refs.
             if isinstance(filtered_doc.get("schemagroups"), dict):
                 referenced_sg_ids = self._collect_referenced_schemagroup_ids(
-                    filtered_doc.get("messagegroups", {}))
+                    filtered_doc.get("messagegroups", {}), document)
                 filtered_doc["schemagroups"] = {
                     sg_id: sg_data
                     for sg_id, sg_data in filtered_doc["schemagroups"].items()

--- a/xrcg/templates/py/amqpproducer/_templateinfo.json
+++ b/xrcg/templates/py/amqpproducer/_templateinfo.json
@@ -2,7 +2,7 @@
   "description": "Python AMQP 1.0 Producer",
   "template_kind": "producer",
   "priority": 1,
-  "main_project_name": "{project_name|dashdot|dotunderscore|lower}AmqpProducer",
-  "data_project_name": "{project_name|dashdot|dotunderscore|lower}Data",
+  "main_project_name": "{project_name|dashdot|dotunderscore|lower}_amqp_producer",
+  "data_project_name": "{project_name|dashdot|dotunderscore|lower}_data",
   "src_layout": false
 }

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -485,12 +485,40 @@ class {{ class_name }}:
         if data is None:
             return b''
         if hasattr(data, 'to_byte_array'):
-            return data.to_byte_array(content_type)
-        if hasattr(data, 'to_dict'):
-            return json.dumps(data.to_dict()).encode('utf-8')
-        if isinstance(data, (bytes, bytearray)):
-            return bytes(data)
-        return json.dumps(data).encode('utf-8')
+            payload = data.to_byte_array(content_type)
+        elif hasattr(data, 'to_dict'):
+            payload = json.dumps(data.to_dict())
+        elif isinstance(data, (bytes, bytearray)):
+            payload = bytes(data)
+        else:
+            payload = json.dumps(data)
+        # to_byte_array may return str for text content types (e.g. JSON);
+        # we always emit bytes so the AMQP body is a binary section rather
+        # than an AMQP string section containing escaped JSON.
+        if isinstance(payload, str):
+            payload = payload.encode('utf-8')
+        return payload
+
+    @staticmethod
+    def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+        """Translate cloudevents-sdk HTTP-style headers (``ce-foo``) into the
+        CloudEvents AMQP 1.0 Protocol Binding (v1.0.2 §3.1) form
+        (``cloudEvents:foo``). ``content-type`` is carried separately on the
+        AMQP properties section and is therefore dropped here.
+        """
+        out: typing.Dict[str, typing.Any] = {}
+        for k, v in (headers or {}).items():
+            if v is None:
+                continue
+            lk = str(k)
+            low = lk.lower()
+            if low.startswith('ce-'):
+                out['cloudEvents:' + lk[3:]] = v
+            elif low == 'content-type':
+                continue
+            else:
+                out[lk] = v
+        return out
 
     {% for messageid, message in messagegroup.messages.items() -%}
     {%- set messagename = messageid | pascal | strip_namespace %}
@@ -583,18 +611,20 @@ class {{ class_name }}:
                 msg_body = body
             else:
                 msg_body = str(body).encode('utf-8')
-            amqp_msg = Message(body=msg_body)
+            amqp_msg = Message(body=msg_body, inferred=True)
             amqp_msg.content_type = self.format_type or headers.get('content-type')
         else:  # binary mode
             headers, body = to_binary(cloud_event)
-            amqp_msg = Message(body=body)
+            if isinstance(body, str):
+                body = body.encode('utf-8')
+            amqp_msg = Message(body=body, inferred=True)
             amqp_msg.content_type = content_type
             if headers:
-                amqp_msg.properties = headers
+                amqp_msg.properties = self._ce_headers_to_amqp_properties(headers)
         {%- else %}
         # Plain AMQP message (non-CloudEvent)
         byte_data = self._serialize_payload(data, content_type)
-        amqp_msg = Message(body=byte_data)
+        amqp_msg = Message(body=byte_data, inferred=True)
         amqp_msg.content_type = content_type
         amqp_msg.properties = {'subject': '{{ messageid }}'}
         {%- endif %}

--- a/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -107,18 +107,27 @@ class {{ class_name }}:
         }
         attributes["datacontenttype"] = content_type
         byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # coerce to bytes so the cloudevents-sdk emits a binary AMQP data
+        # section rather than a string section containing escaped JSON.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
         event = CloudEvent(attributes, byte_data)
         if self.content_mode == "structured":
             headers, body = to_structured(event)
         else:
             headers, body = to_binary(event)
+        if isinstance(body, str):
+            body = body.encode('utf-8')
         event_data = EventData(body)
         if "Content-Type" in headers:
             event_data.content_type = headers["Content-Type"]
             del headers["Content-Type"]
         for key, value in headers.items():
             if key.lower().startswith("ce-"):
-                event_data.properties["cloudEvents_"+key[3:]] = value
+                # CloudEvents AMQP Protocol Binding v1.0.2 §3.1 mandates the
+                # 'cloudEvents:' prefix on application-properties keys.
+                event_data.properties["cloudEvents:"+key[3:]] = value
             else:
                 event_data.properties[key] = value
         await self.producer.send_event(event_data)

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -428,14 +428,24 @@ class {{ class_name }}(_ClientBase):
             {%- endfor %}
         {%- endif %}
     {%- endif %}
-    {#- Per-message QoS and retain defaults pulled from protocoloptions (direct scalars per spec). -#}
+    {#- Per-message QoS and retain defaults pulled from protocoloptions.
+        Supports both the direct-scalar form (protocoloptions.qos = 1) and the
+        spec's properties-map form (protocoloptions.properties.qos.value = 1). -#}
     {%- set default_qos = 1 %}
-    {%- if message.protocoloptions and message.protocoloptions.qos is not none -%}
+    {%- if message.protocoloptions and message.protocoloptions.qos is defined and message.protocoloptions.qos is not none -%}
         {%- set default_qos = message.protocoloptions.qos %}
+    {%- elif message.protocoloptions and message.protocoloptions.properties is defined and message.protocoloptions.properties and message.protocoloptions.properties.qos is defined and message.protocoloptions.properties.qos and message.protocoloptions.properties.qos.value is defined and message.protocoloptions.properties.qos.value is not none -%}
+        {%- set default_qos = message.protocoloptions.properties.qos.value %}
     {%- endif %}
     {%- set default_retain = "False" %}
-    {%- if message.protocoloptions and message.protocoloptions.retain is not none -%}
+    {%- if message.protocoloptions and message.protocoloptions.retain is defined and message.protocoloptions.retain is not none -%}
         {%- if message.protocoloptions.retain -%}
+            {%- set default_retain = "True" %}
+        {%- else -%}
+            {%- set default_retain = "False" %}
+        {%- endif %}
+    {%- elif message.protocoloptions and message.protocoloptions.properties is defined and message.protocoloptions.properties and message.protocoloptions.properties.retain is defined and message.protocoloptions.properties.retain and message.protocoloptions.properties.retain.value is defined and message.protocoloptions.properties.retain.value is not none -%}
+        {%- if message.protocoloptions.properties.retain.value -%}
             {%- set default_retain = "True" %}
         {%- else -%}
             {%- set default_retain = "False" %}
@@ -507,6 +517,13 @@ class {{ class_name }}(_ClientBase):
         }
         attributes["datacontenttype"] = content_type
         byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON);
+        # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's
+        # to_binary/to_structured embed the str directly which then becomes
+        # a JSON string literal containing the JSON document. Coerce to
+        # bytes up-front so receivers can json.loads(payload) once.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
         event = CloudEvent(attributes, byte_data)
 
         _effective_qos = {{ default_qos }} if qos is None else qos
@@ -526,6 +543,15 @@ class {{ class_name }}(_ClientBase):
             mqtt5_props = _ce_headers_to_mqtt5_properties(dict(headers or {}))
             if mqtt5_props is not None:
                 publish_kwargs["properties"] = mqtt5_props
+
+        # Ensure the MQTT PUBLISH payload is bytes so it is sent as the
+        # exact serialized representation; paho-mqtt would UTF-8 encode a
+        # str, but a dict (from structured mode) would crash, and any
+        # double-encoding upstream would land on the wire untouched.
+        if isinstance(payload, dict):
+            payload = json.dumps(payload).encode('utf-8')
+        elif isinstance(payload, str):
+            payload = payload.encode('utf-8')
 
         self.client.publish(target_topic, payload, **publish_kwargs)
 

--- a/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -126,11 +126,18 @@ class {{ class_name }}:
         }
         attributes["datacontenttype"] = content_type
         byte_data = data.to_byte_array(content_type) if data is not None else b''
+        # to_byte_array returns str for text content types (e.g. JSON); coerce
+        # to bytes so the wire body is the exact serialized representation
+        # (binary AMQP data section) and receivers do not double-decode JSON.
+        if isinstance(byte_data, str):
+            byte_data = byte_data.encode('utf-8')
         event = CloudEvent(attributes, byte_data)
         
         async with self.servicebus_client.get_queue_sender(queue_name=self.queue_or_topic_name) as sender:
             if self.content_mode == "structured":
                 headers, body = to_structured(event)
+                if isinstance(body, str):
+                    body = body.encode('utf-8')
                 message = ServiceBusMessage(body=body)
                 if "Content-Type" in headers:
                     message.content_type = headers["Content-Type"]
@@ -139,6 +146,8 @@ class {{ class_name }}:
                     message.application_properties = {}
             else:
                 headers, body = to_binary(event)
+                if isinstance(body, str):
+                    body = body.encode('utf-8')
                 message = ServiceBusMessage(body=body)
                 message.content_type = attributes.get("datacontenttype", "application/octet-stream")
                 # Initialize application_properties dict if not already set

--- a/xrcg/templates/ts/amqpproducer/src/producer.ts.jinja
+++ b/xrcg/templates/ts/amqpproducer/src/producer.ts.jinja
@@ -130,31 +130,51 @@ export class {{ class_name }} {
             
             let message: rhea.Message;
             if (this.mode === 'structured') {
+                const structuredBody = cloudEvent.toJSON();
                 message = {
-                    body: cloudEvent.toJSON(),
+                    body: typeof structuredBody === 'string'
+                        ? Buffer.from(structuredBody, 'utf-8')
+                        : Buffer.from(JSON.stringify(structuredBody), 'utf-8'),
                     content_type: this.format
                 };
             } else {
+                // CloudEvents AMQP Protocol Binding v1.0.2 §3.1: application
+                // properties carrying CE attributes MUST be prefixed with
+                // 'cloudEvents:' (not 'ce-' from the HTTP binding, and not
+                // 'ce_' from the Kafka binding).
                 const application_properties: Record<string, any> = {
-                    ce_specversion: '1.0',
-                    ce_id: cloudEvent.id,
-                    ce_type: cloudEvent.type,
-                    ce_source: cloudEvent.source
+                    'cloudEvents:specversion': '1.0',
+                    'cloudEvents:id': cloudEvent.id,
+                    'cloudEvents:type': cloudEvent.type,
+                    'cloudEvents:source': cloudEvent.source
                 };
-                if (cloudEvent.subject) application_properties.ce_subject = cloudEvent.subject;
-                if (cloudEvent.time) application_properties.ce_time = cloudEvent.time;
+                if (cloudEvent.subject) application_properties['cloudEvents:subject'] = cloudEvent.subject;
+                if (cloudEvent.time) application_properties['cloudEvents:time'] = cloudEvent.time;
                 {%- for attrname, attribute in message.envelopemetadata.items() if attrname not in ["id", "type", "source", "subject", "time", "specversion", "datacontenttype", "dataschema", "data"] %}
-                if ((cloudEvent as any).{{ attrname }}) application_properties.ce_{{ attrname }} = (cloudEvent as any).{{ attrname }};
+                if ((cloudEvent as any).{{ attrname }}) application_properties['cloudEvents:{{ attrname }}'] = (cloudEvent as any).{{ attrname }};
                 {%- endfor %}
+                // Coerce body to Buffer so rhea emits an AMQP binary data
+                // section; string bodies become AMQP string sections and cause
+                // double-encoding of JSON payloads on the wire.
+                const binaryBody = typeof data === 'string'
+                    ? Buffer.from(data, 'utf-8')
+                    : (data instanceof Uint8Array || Buffer.isBuffer(data))
+                        ? Buffer.from(data as Uint8Array)
+                        : Buffer.from(JSON.stringify(data), 'utf-8');
                 message = {
-                    body: data,
+                    body: binaryBody,
                     content_type: contentType,
                     application_properties
                 };
             }
             {%- else %}
+            const plainBody = typeof data === 'string'
+                ? Buffer.from(data, 'utf-8')
+                : (data instanceof Uint8Array || Buffer.isBuffer(data))
+                    ? Buffer.from(data as Uint8Array)
+                    : Buffer.from(JSON.stringify(data), 'utf-8');
             const message: rhea.Message = {
-                body: data,
+                body: plainBody,
                 application_properties: {
                     subject: '{{ messageid }}'
                 },

--- a/xrcg/templates/ts/ehproducer/src/producer.ts.jinja
+++ b/xrcg/templates/ts/ehproducer/src/producer.ts.jinja
@@ -168,17 +168,17 @@ export class {{ class_name }} {
                 body: data,
                 contentType: contentType,
                 properties: {
-                    'ce_specversion': '1.0',
-                    'ce_id': cloudEvent.id,
-                    'ce_type': cloudEvent.type,
-                    'ce_source': cloudEvent.source
+                    'cloudEvents:specversion': '1.0',
+                    'cloudEvents:id': cloudEvent.id,
+                    'cloudEvents:type': cloudEvent.type,
+                    'cloudEvents:source': cloudEvent.source
                 }
             };
             
             {%- for attrname, attribute in message.envelopemetadata.items() %}
             {%- if attrname not in ["id", "type", "source", "specversion", "datacontenttype", "data"] %}
             if (cloudEvent.{{ attrname }}) {
-                eventData.properties!['ce_{{ attrname }}'] = String(cloudEvent.{{ attrname }});
+                eventData.properties!['cloudEvents:{{ attrname }}'] = String(cloudEvent.{{ attrname }});
             }
             {%- endif %}
             {%- endfor %}
@@ -276,16 +276,16 @@ export class {{ class_name }} {
             } else {
                 // Binary content mode
                 const properties: Record<string, any> = {
-                    'ce_specversion': '1.0',
-                    'ce_id': cloudEvent.id,
-                    'ce_type': cloudEvent.type,
-                    'ce_source': cloudEvent.source
+                    'cloudEvents:specversion': '1.0',
+                    'cloudEvents:id': cloudEvent.id,
+                    'cloudEvents:type': cloudEvent.type,
+                    'cloudEvents:source': cloudEvent.source
                 };
                 
                 {%- for attrname, attribute in message.envelopemetadata.items() %}
                 {%- if attrname not in ["id", "type", "source", "specversion", "datacontenttype", "data"] %}
                 if (cloudEvent.{{ attrname }}) {
-                    properties['ce_{{ attrname }}'] = String(cloudEvent.{{ attrname }});
+                    properties['cloudEvents:{{ attrname }}'] = String(cloudEvent.{{ attrname }});
                 }
                 {%- endif %}
                 {%- endfor %}

--- a/xrcg/templates/ts/sbproducer/src/producer.ts.jinja
+++ b/xrcg/templates/ts/sbproducer/src/producer.ts.jinja
@@ -195,17 +195,17 @@ export class {{ class_name }} {
                 body: data,
                 contentType: contentType,
                 applicationProperties: {
-                    'ce_specversion': '1.0',
-                    'ce_id': cloudEvent.id,
-                    'ce_type': cloudEvent.type,
-                    'ce_source': cloudEvent.source
+                    'cloudEvents:specversion': '1.0',
+                    'cloudEvents:id': cloudEvent.id,
+                    'cloudEvents:type': cloudEvent.type,
+                    'cloudEvents:source': cloudEvent.source
                 }
             };
             
             {%- for attrname, attribute in message.envelopemetadata.items() %}
             {%- if attrname not in ["id", "type", "source", "specversion", "datacontenttype", "data"] %}
             if (cloudEvent.{{ attrname }}) {
-                message.applicationProperties!['ce_{{ attrname }}'] = String(cloudEvent.{{ attrname }});
+                message.applicationProperties!['cloudEvents:{{ attrname }}'] = String(cloudEvent.{{ attrname }});
             }
             {%- endif %}
             {%- endfor %}
@@ -296,15 +296,15 @@ export class {{ class_name }} {
                 };
             } else {
                 const applicationProperties: Record<string, any> = {
-                    ce_specversion: '1.0',
-                    ce_id: cloudEvent.id,
-                    ce_type: cloudEvent.type,
-                    ce_source: cloudEvent.source
+                    'cloudEvents:specversion': '1.0',
+                    'cloudEvents:id': cloudEvent.id,
+                    'cloudEvents:type': cloudEvent.type,
+                    'cloudEvents:source': cloudEvent.source
                 };
-                if (cloudEvent.subject) applicationProperties.ce_subject = cloudEvent.subject;
-                if (cloudEvent.time) applicationProperties.ce_time = cloudEvent.time;
+                if (cloudEvent.subject) applicationProperties['cloudEvents:subject'] = cloudEvent.subject;
+                if (cloudEvent.time) applicationProperties['cloudEvents:time'] = cloudEvent.time;
                 {%- for attrname, attribute in message.envelopemetadata.items() if attrname not in ["id", "type", "source", "subject", "time", "specversion", "datacontenttype", "dataschema", "data"] %}
-                if ((cloudEvent as any).{{ attrname }}) applicationProperties.ce_{{ attrname }} = (cloudEvent as any).{{ attrname }};
+                if ((cloudEvent as any).{{ attrname }}) applicationProperties['cloudEvents:{{ attrname }}'] = (cloudEvent as any).{{ attrname }};
                 {%- endfor %}
                 return {
                     body: data,


### PR DESCRIPTION
Two wire-format bugs observed against real CloudEvents consumers.

## Bug 1 - AMQP CE attribute prefix (spec compliance)
The CloudEvents AMQP Protocol Binding v1.0.2 §3.1 mandates `cloudEvents:` as the application-properties prefix for CE attributes. The Python AMQP producer was assigning the cloudevents-sdk's raw HTTP-style `ce-foo` headers dict directly to `amqp_msg.properties`, so any compliant CE-AMQP consumer (`azure-servicebus`'s `CloudEvent.from_message`, NATS adapters, Knative eventing) failed to recognize the messages as CloudEvents.

**Fix**: `_ce_headers_to_amqp_properties()` translates `ce-foo` → `cloudEvents:foo` and drops `content-type` (which travels on the AMQP properties section, not application-properties).

## Bug 2 - JSON body double-encoded (AMQP + MQTT)
The generated dataclass `to_byte_array('application/json')` returns a `str` (the JSON text). The producer was passing that string to `proton.Message(body=...)`, which AMQP-encoded it as a string section on the wire — subscribers had to `json.loads()` twice. Same hazard in the MQTT client where `dict` (structured-mode) or `str` payloads were handed to paho-mqtt.

**Fix**: coerce `str` → `bytes` in `_serialize_payload` and at the MQTT payload boundary; instantiate `proton.Message` with `inferred=True` so bytes become an AMQP binary section.

## Tests
Four new codegen-introspection tests in `test/py/test_python.py` that guard the wire format without needing a broker:
- `test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix`
- `test_amqpproducer_body_is_bytes_with_inferred_true`
- `test_amqpproducer_non_cloudevent_body_is_bytes_with_inferred_true`
- `test_mqttclient_body_is_bytes_not_str`

All four pass; existing AMQP CBS tests still green.