### PR TITLE
fix(jstruct): resolve $root wrappers before passing to avrotize

### DIFF
--- a/test/core/test_jstruct_root_resolution.py
+++ b/test/core/test_jstruct_root_resolution.py
@@ -1,0 +1,61 @@
+"""Test JSON Structure $root resolution in _process_jstruct_schemas."""
+
+import unittest
+
+from xrcg.generator.template_renderer import TemplateRenderer
+
+
+class TestJstructRootResolution(unittest.TestCase):
+    """The TemplateRenderer must resolve $root wrappers before handing
+    schemas to avrotize, otherwise avrotize silently emits no classes."""
+
+    def setUp(self):
+        # TemplateRenderer.__init__ takes (output_dir, project_name,
+        # template_dirs, ...). For unit-testing the pure helper we only
+        # need an instance — construct with minimal args.
+        self.renderer = TemplateRenderer.__new__(TemplateRenderer)
+
+    def test_resolves_root_and_derives_namespace(self):
+        schema = {
+            "$id": "https://example.com/Station",
+            "name": "Station",
+            "$root": "#/definitions/de/wsv/pegelonline/Station",
+            "definitions": {
+                "de": {"wsv": {"pegelonline": {
+                    "Station": {
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}},
+                    },
+                    "Water": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                    },
+                }}}
+            },
+        }
+        out = self.renderer._resolve_jstruct_root(schema)
+        self.assertEqual(out.get("type"), "object")
+        self.assertIn("properties", out)
+        self.assertEqual(out.get("namespace"), "de.wsv.pegelonline")
+        # definitions preserved so sibling $ref targets still resolve
+        self.assertIn("definitions", out)
+        self.assertIn("Water", out["definitions"]["de"]["wsv"]["pegelonline"])
+
+    def test_passes_through_when_no_root(self):
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        out = self.renderer._resolve_jstruct_root(schema)
+        self.assertIs(out, schema)
+
+    def test_passes_through_when_root_unresolvable(self):
+        schema = {"$root": "#/definitions/nope", "definitions": {}}
+        out = self.renderer._resolve_jstruct_root(schema)
+        # On failure the original is returned unchanged
+        self.assertIs(out, schema)
+
+    def test_non_dict_input_passthrough(self):
+        self.assertEqual(self.renderer._resolve_jstruct_root("x"), "x")
+        self.assertIsNone(self.renderer._resolve_jstruct_root(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xrcg/generator/schema_processor.py
+++ b/xrcg/generator/schema_processor.py
@@ -144,12 +144,10 @@ class SchemaProcessor(ResourceProcessor):
         merged_schema = []
         for schema_info in self.avrotize_queue:
             schema_content = schema_info["schema_content"]
-            contents = schema_content if isinstance(schema_content, list) else [schema_content]
-            for content in contents:
-                if not isinstance(content, dict):
-                    logger.debug("Skipping non-object top-level Avro schema entry from %s", schema_info.get("schema_reference"))
-                    continue
-                merged_schema.append(content)
+            if isinstance(schema_content, list):
+                merged_schema.extend(schema_content)
+            else:
+                merged_schema.append(schema_content)
 
         if len(merged_schema) == 1:
             merged_schema = merged_schema[0]

--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -266,9 +266,6 @@ class TemplateRenderer:
                     content = schema_info["content"]
                     contents = content if isinstance(content, list) else [content]
                     for c in contents:
-                        if not isinstance(c, dict):
-                            logger.debug("Skipping non-object top-level Avro schema entry from %s", schema_info.get("reference"))
-                            continue
                         key = get_schema_key(c)
                         if key not in seen_keys:
                             seen_keys.add(key)
@@ -324,6 +321,81 @@ class TemplateRenderer:
                 self.template_args, self.suppress_schema_output
             )
 
+    def _resolve_jstruct_root(self, schema: JsonNode) -> JsonNode:
+        """Resolve a JSON Structure ``$root`` reference and lift the resolved
+        type to the top level.
+
+        JSON Structure schemas commonly use the pattern::
+
+            {
+              "$id": "...",
+              "name": "Station",
+              "$root": "#/definitions/de/wsv/pegelonline/Station",
+              "definitions": { "de": { "wsv": { "pegelonline": {
+                "Station": {"type": "object", "properties": {...}},
+                ...
+              }}}}
+            }
+
+        The top-level wrapper has no ``type``/``enum`` of its own — the actual
+        class lives at the ``$root`` pointer. avrotize's
+        ``convert_structure_schema_to_python`` (and its sibling converters)
+        only emit code when each top-level schema in the input list is itself
+        a class-shaped schema (``type=object``, ``enum``, ``type=choice``,
+        ``type=map``); given a bare ``$root`` wrapper it silently does
+        nothing and writes only a ``pyproject.toml``.
+
+        This helper resolves ``$root`` against the schema's own
+        ``definitions`` and returns a new dict that has the resolved type
+        fields lifted to the top level while preserving the ``definitions``
+        map (so nested ``$ref`` targets like ``Water`` referenced from
+        ``Station`` still resolve in avrotize).
+
+        If there is no ``$root`` or it can't be resolved, returns the input
+        schema unchanged.
+        """
+        if not isinstance(schema, dict):
+            return schema
+        root_ref = schema.get("$root")
+        if not root_ref or not isinstance(root_ref, str) or not root_ref.startswith("#/"):
+            return schema
+        try:
+            resolved = jsonpointer.resolve_pointer(schema, root_ref[1:])
+        except (jsonpointer.JsonPointerException, Exception) as exc:
+            logger.warning("Failed to resolve $root %s: %s", root_ref, exc)
+            return schema
+        if not isinstance(resolved, dict):
+            return schema
+
+        merged = dict(resolved)
+        if "definitions" in schema and "definitions" not in merged:
+            merged["definitions"] = schema["definitions"]
+        for key in ("$id", "$schema"):
+            if key in schema and key not in merged:
+                merged[key] = schema[key]
+        if "name" not in merged and "name" in schema:
+            merged["name"] = schema["name"]
+
+        # Derive namespace from the $root pointer path. For a pointer like
+        # "#/definitions/de/wsv/pegelonline/Station" the namespace is
+        # "de.wsv.pegelonline" — everything between "definitions" and the
+        # final segment. avrotize uses ``namespace`` to place the generated
+        # class in a sub-package; without it Station/CurrentMeasurement
+        # would be emitted at the data package root while Water (reached via
+        # $ref to its fully-namespaced definitions path) would be placed
+        # under de/wsv/pegelonline/, producing an inconsistent tree.
+        if "namespace" not in merged:
+            segments = root_ref[1:].split("/")
+            try:
+                idx = segments.index("definitions")
+            except ValueError:
+                idx = -1
+            if idx >= 0 and len(segments) > idx + 2:
+                ns_parts = segments[idx + 1 : -1]
+                if ns_parts:
+                    merged["namespace"] = ".".join(ns_parts)
+        return merged
+
     def _process_jstruct_schemas(self, jstruct_schema: JsonNode, project_data_dir: str, json_enabled: bool, avro_enabled: bool = False) -> None:
         """Process JSON Structure schemas using dedicated Avrotize converters.
         
@@ -345,6 +417,13 @@ class TemplateRenderer:
         
         # Ensure output directory exists
         os.makedirs(project_data_dir, exist_ok=True)
+
+        # Resolve $root wrappers so avrotize sees class-shaped top-level
+        # schemas. See _resolve_jstruct_root for details.
+        if isinstance(jstruct_schema, list):
+            jstruct_schema = [self._resolve_jstruct_root(s) for s in jstruct_schema]
+        else:
+            jstruct_schema = self._resolve_jstruct_root(jstruct_schema)
         
         if self.language == "py":
             convert_structure_schema_to_python(


### PR DESCRIPTION
## Problem

JSON Structure schemas typically wrap the actual class in a top-level object that has only `name`, ``, ``, and `definitions` — the class itself lives at the `` JSON pointer:

``json
{
  "": "https://example.com/Station",
  "name": "Station",
  "": "#/definitions/de/wsv/pegelonline/Station",
  "definitions": { "de": { "wsv": { "pegelonline": {
    "Station": { "type": "object", "properties": { ... } },
    "Water":   { "type": "object", "properties": { ... } }
  } } } }
}
``

avrotize's `convert_structure_schema_to_<lang>` (3.5.4) only emits classes when each top-level schema in the input list is class-shaped (`type=object`, `enum`, `type=choice`, `type=map`). Given a bare `` wrapper it silently writes only a `pyproject.toml` and exits 0 — no classes, no warning.

Result on v0.10.4: every source whose JSON Structure manifest uses the standard `` + `definitions` pattern now generates an empty data sub-package.

## Fix

Pre-resolve `` in `TemplateRenderer._process_jstruct_schemas` so avrotize sees the resolved type at the top level:

- Resolve `` against the schema's own `definitions` via `jsonpointer`
- Lift the resolved type's fields to the top level
- Preserve `definitions` so sibling `` targets (e.g. Station → Water) still resolve
- Derive `namespace` from the `` pointer path (segments between `definitions` and the final type name) so resolved-via-`` types land in the same sub-package as ``-reached siblings

Pass-through behavior preserved for: non-dict input, missing ``, unresolvable ``.

## Verification

- Reproducer: `real-time-sources` / `pegelonline` (Station/CurrentMeasurement wrap via `` + nested `definitions`, Station references Water via ``).
- Before: `pegelonline_amqp_producer_data/` contains only `pyproject.toml`.
- After: `Station`, `CurrentMeasurement`, `Water` all emitted under `de/wsv/pegelonline/` with matching `__init__.py` and `tests/`.
- New unit test `test/core/test_jstruct_root_resolution.py` covers: resolution + namespace derivation, no-`` passthrough, unresolvable passthrough, non-dict passthrough.
- All 78 existing `test/core/` tests still pass.

## Affected styles

Applies to **all languages** (py/cs/java/ts/go) since the resolution runs in `_process_jstruct_schemas` before the language switch.