### PR TITLE
Fix Python AMQP application properties

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -505,6 +505,28 @@ def test_amqpproducer_non_cloudevent_body_is_bytes_with_inferred_true():
     )
 
 
+def test_amqpproducer_protocoloptions_application_properties_codegen():
+    """AMQP protocoloptions.application_properties must become send
+    parameters and qpid-proton application-properties.
+    """
+    src = _generate_amqp_producer_src("test/xreg/lightbulb-amqp.xreg.json")
+    sig_start = src.index("def send_turned_on(")
+    sig_end = src.index(") -> None:", sig_start)
+    send_signature = src[sig_start:sig_end]
+    batch_sig_start = src.index("def send_turned_on_batch(")
+    batch_sig_end = src.index(") -> None:", batch_sig_start)
+    batch_signature = src[batch_sig_start:batch_sig_end]
+    assert send_signature.count("_tenantid: str") == 1
+    assert send_signature.count("_deviceid: str") == 1
+    assert batch_signature.count("_tenantid: str") == 1
+    assert batch_signature.count("_deviceid: str") == 1
+    assert 'amqp_msg.subject = "{tenantid}".format(tenantid=_tenantid)' in src
+    assert 'app_properties["water_shortname"] = "{deviceid}".format(deviceid=_deviceid)' in src
+    assert "_tenantid=_tenantid" in src
+    assert "_deviceid=_deviceid" in src
+    assert "amqp_msg.properties.update(app_properties)" in src
+
+
 def test_mqttclient_body_is_bytes_not_str():
     """The MQTT PUBLISH payload MUST be bytes. ``to_byte_array`` returns
     ``str`` for text content types; the client must coerce to bytes

--- a/test/xreg/lightbulb-amqp.xreg.json
+++ b/test/xreg/lightbulb-amqp.xreg.json
@@ -7,11 +7,20 @@
                     "description": "Event for when the bulb is turned on",
                     "protocol": "AMQP/1.0",
                     "protocoloptions": {
-                        "application_properties": {
+                        "properties": {
                             "subject": {
+                                "type": "uritemplate",
                                 "required": true,
-                                "value": "Fabrikam.Lumen.TurnedOn",
-                                "description": "Event raised when the bulb is turned on"
+                                "value": "{tenantid}",
+                                "description": "AMQP message subject for routing"
+                            }
+                        },
+                        "application_properties": {
+                            "water_shortname": {
+                                "type": "uritemplate",
+                                "required": true,
+                                "value": "{deviceid}",
+                                "description": "Application property used by AMQP routers and filters"
                             }
                         }
                     },

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -6,6 +6,38 @@
 {%- error "azure_cbs_target must be 'eventhubs' or 'servicebus' (got: " ~ _azure_cbs_target ~ "), or pass --template-args azure_cbs_audience=<scope> for a custom audience" %}
 {%- endif %}
 {%- set _azure_cbs_audience = (azure_cbs_audience | default(none)) or azure_audience_map.get(_azure_cbs_target) %}
+{%- set amqp_message_property_attributes = {
+    'message-id': 'id',
+    'message_id': 'id',
+    'id': 'id',
+    'user-id': 'user_id',
+    'user_id': 'user_id',
+    'to': 'address',
+    'address': 'address',
+    'subject': 'subject',
+    'reply-to': 'reply_to',
+    'reply_to': 'reply_to',
+    'correlation-id': 'correlation_id',
+    'correlation_id': 'correlation_id',
+    'content-type': 'content_type',
+    'content_type': 'content_type',
+    'content-encoding': 'content_encoding',
+    'content_encoding': 'content_encoding',
+    'absolute-expiry-time': 'expiry_time',
+    'absolute_expiry_time': 'expiry_time',
+    'creation-time': 'creation_time',
+    'creation_time': 'creation_time',
+    'group-id': 'group_id',
+    'group_id': 'group_id',
+    'group-sequence': 'group_sequence',
+    'group_sequence': 'group_sequence',
+    'reply-to-group-id': 'reply_to_group_id',
+    'reply_to_group_id': 'reply_to_group_id'
+} %}
+{%- macro protocol_option_value(prop) -%}
+{%- set phs = prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+"{{ prop.value }}"{%- if phs -%}.format({%- for placeholder in phs -%}{{ placeholder }}=_{{ placeholder | snake }}{% if not loop.last %}, {% endif %}{%- endfor -%}){%- endif -%}
+{%- endmacro %}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 
@@ -644,6 +676,40 @@ class {{ class_name }}:
     {%- set messagename = messageid | pascal | strip_namespace %}
     {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
+    {%- set protocoloptions = message.protocoloptions if message.protocoloptions is defined and message.protocoloptions else {} %}
+    {%- set message_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
+    {%- set message_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
+    {%- set ce_arg_names = namespace(items=[]) %}
+    {%- if isCloudEvent %}
+    {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
+    {%- set _ = ce_arg_names.items.append(attrname | snake) %}
+    {%- endfor %}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+    {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+    {%- set argname = placeholder | snake %}
+    {%- if argname not in ce_arg_names.items %}
+    {%- set _ = ce_arg_names.items.append(argname) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- endfor %}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
+    {%- set argname = attrname | snake %}
+    {%- if argname not in ce_arg_names.items %}
+    {%- set _ = ce_arg_names.items.append(argname) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- endif %}
+    {%- set protocol_option_arg_names = namespace(items=[]) %}
+    {%- for propmap in [message_properties, message_application_properties] if propmap %}
+    {%- for propname, prop in propmap.items() if prop.value is defined %}
+    {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+    {%- set argname = placeholder | snake %}
+    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items %}
+    {%- set _ = protocol_option_arg_names.items.append(argname) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- endfor %}
+    {%- endfor %}
     
     def send_{{ messagename | snake }}(self,
         data: {{ type_name }},
@@ -660,6 +726,9 @@ class {{ class_name }}:
         {% if not attribute.required %}_{{ attrname }}: typing.Optional[str] = None,{% else %}_{{ attrname }}: str,{% endif %}
         {%- endfor %}
         {%- endif %}
+        {%- for argname in protocol_option_arg_names.items %}
+        _{{ argname }}: str,
+        {%- endfor %}
         content_type: str = 'application/json') -> None:
         """
         Send the `{{ messageid }}` message
@@ -681,6 +750,9 @@ class {{ class_name }}:
             _{{ attrname }} ({% if not attribute.required %}typing.Optional[str]{% else %}str{% endif %}): CloudEvent {{ attrname }} attribute
         {%- endfor %}
         {%- endif %}
+        {%- for argname in protocol_option_arg_names.items %}
+            _{{ argname }} (str): Value for AMQP protocol option placeholder {{ argname }}
+        {%- endfor %}
             data ({{ type_name }}): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -746,8 +818,29 @@ class {{ class_name }}:
         byte_data = self._serialize_payload(data, content_type)
         amqp_msg = Message(body=byte_data, inferred=True)
         amqp_msg.content_type = content_type
-        amqp_msg.properties = {'subject': '{{ messageid }}'}
         {%- endif %}
+
+        {%- if message_properties %}
+        # Apply AMQP message properties declared in protocoloptions.properties.
+        {%- for propname, prop in message_properties.items() if prop.value is defined %}
+        {%- set property_key = propname | lower %}
+        {%- if property_key in amqp_message_property_attributes %}
+        amqp_msg.{{ amqp_message_property_attributes[property_key] }} = {{ protocol_option_value(prop) }}
+        {%- endif %}
+        {%- endfor %}
+        {%- endif %}
+
+        app_properties = {}
+        {%- if (not isCloudEvent) and ('subject' not in message_properties) and ('subject' not in message_application_properties) %}
+        app_properties["subject"] = "{{ messageid }}"
+        {%- endif %}
+        {%- for propname, prop in message_application_properties.items() if prop.value is defined %}
+        app_properties["{{ propname }}"] = {{ protocol_option_value(prop) }}
+        {%- endfor %}
+        if app_properties:
+            if amqp_msg.properties is None:
+                amqp_msg.properties = {}
+            amqp_msg.properties.update(app_properties)
         
         # Send message
         {%- if _azure_cbs_target %}
@@ -762,6 +855,9 @@ class {{ class_name }}:
     def send_{{ messagename | snake }}_batch(self,
         data_array: typing.List[{{ type_name }}],
         {%- if isCloudEvent %}
+        {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
+        _{{ attrname }}: str,
+        {%- endfor %}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
         _{{ placeholder | snake }}: str,
@@ -771,6 +867,9 @@ class {{ class_name }}:
         {% if not attribute.required %}_{{ attrname }}: typing.Optional[str] = None,{% else %}_{{ attrname }}: str,{% endif %}
         {%- endfor %}
         {%- endif %}
+        {%- for argname in protocol_option_arg_names.items %}
+        _{{ argname }}: str,
+        {%- endfor %}
         content_type: str = 'application/json') -> None:
         """
         Send multiple `{{ messageid }}` messages
@@ -778,6 +877,9 @@ class {{ class_name }}:
         Args:
             data_array (typing.List[{{ type_name }}]): Array of message data objects
         {%- if isCloudEvent %}
+        {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
+            _{{ attrname }} (str): CloudEvents required attribute '{{ attrname }}'
+        {%- endfor %}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }} (str): Value for placeholder {{ placeholder }} in attribute {{ attrname }}
@@ -787,10 +889,31 @@ class {{ class_name }}:
             _{{ attrname }} ({% if not attribute.required %}typing.Optional[str]{% else %}str{% endif %}): CloudEvent {{ attrname }} attribute
         {%- endfor %}
         {%- endif %}
+        {%- for argname in protocol_option_arg_names.items %}
+            _{{ argname }} (str): Value for AMQP protocol option placeholder {{ argname }}
+        {%- endfor %}
             content_type (str): The content type of the message data
         """
         for data in data_array:
-            self.send_{{ messagename | snake }}(data, {% if isCloudEvent %}{% for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}{% for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }}, {% endfor %}{% endfor %}{% for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}_{{ attrname }}, {% endfor %}{% endif %}content_type)
+            self.send_{{ messagename | snake }}(
+                data=data,
+                {%- if isCloudEvent %}
+                {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
+                _{{ attrname }}=_{{ attrname }},
+                {%- endfor %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+                _{{ placeholder | snake }}=_{{ placeholder | snake }},
+                {%- endfor %}
+                {%- endfor %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
+                _{{ attrname }}=_{{ attrname }},
+                {%- endfor %}
+                {%- endif %}
+                {%- for argname in protocol_option_arg_names.items %}
+                _{{ argname }}=_{{ argname }},
+                {%- endfor %}
+                content_type=content_type)
     {% endfor %}
     
     def close(self) -> None:

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -20,6 +20,39 @@ from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
 from proton.utils import BlockingConnection
 
+{%- set amqp_message_property_attributes = {
+    'message-id': 'id',
+    'message_id': 'id',
+    'id': 'id',
+    'user-id': 'user_id',
+    'user_id': 'user_id',
+    'to': 'address',
+    'address': 'address',
+    'subject': 'subject',
+    'reply-to': 'reply_to',
+    'reply_to': 'reply_to',
+    'correlation-id': 'correlation_id',
+    'correlation_id': 'correlation_id',
+    'content-type': 'content_type',
+    'content_type': 'content_type',
+    'content-encoding': 'content_encoding',
+    'content_encoding': 'content_encoding',
+    'absolute-expiry-time': 'expiry_time',
+    'absolute_expiry_time': 'expiry_time',
+    'creation-time': 'creation_time',
+    'creation_time': 'creation_time',
+    'group-id': 'group_id',
+    'group_id': 'group_id',
+    'group-sequence': 'group_sequence',
+    'group_sequence': 'group_sequence',
+    'reply-to-group-id': 'reply_to_group_id',
+    'reply_to_group_id': 'reply_to_group_id'
+} %}
+{%- macro protocol_option_expected_value(prop) -%}
+{%- set phs = prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+"{{ prop.value }}"{%- if phs -%}.format({%- for placeholder in phs -%}{{ placeholder }}="value"{% if not loop.last %}, {% endif %}{%- endfor -%}){%- endif -%}
+{%- endmacro %}
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../{{data_project_name}}/src')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../{{data_project_name}}/tests')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../{{main_project_name}}/src')))
@@ -270,6 +303,9 @@ class Test{{ class_name }}:
     {%- set messagename = messageid | pascal | strip_namespace %}
     {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
+    {%- set protocoloptions = message.protocoloptions if message.protocoloptions is defined and message.protocoloptions else {} %}
+    {%- set message_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
+    {%- set message_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
     
     def test_send_{{ messagename | snake }}(self, artemis_container):
         """Send and receive a {{ messagename }} message via ActiveMQ Artemis."""
@@ -306,21 +342,30 @@ class Test{{ class_name }}:
                     {%- set _ = extra_args.items.append('_' + attrname) %}
                 {%- endfor %}
             {%- endif %}
+            {%- for propmap in [message_properties, message_application_properties] if propmap %}
+                {%- for propname, prop in propmap.items() if prop.value is defined %}
+                    {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+                        {%- set arg = '_' + (placeholder | snake) %}
+                        {%- if arg not in extra_args.items %}
+                            {%- set _ = extra_args.items.append(arg) %}
+                        {%- endif %}
+                    {%- endfor %}
+                {%- endfor %}
+            {%- endfor %}
             # Send 5 messages to test proper message settlement and ordering
             for i in range(5):
                 producer.send_{{ messagename | snake }}(
                     data=payload,
                 {%- for arg in extra_args.items %}
-                    {{ arg }}="value"{% if not loop.last %},
-                {% endif %}
+                    {{ arg }}="value",
                 {%- endfor %}
-                {% if extra_args.items %},
-                {% endif %}content_type="application/json"
+                    content_type="application/json"
                 )
 
             # Receive and verify all 5 messages
             for i in range(5):
                 received = _receive_single_message(artemis_container)
+                properties = received.properties or {}
 
                 if {{ 'True' if isCloudEvent else 'False' }}:
                     body = received.body
@@ -339,10 +384,25 @@ class Test{{ class_name }}:
                     # Verify data section exists (either as data or data_base64)
                     assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
                 else:
-                    properties = received.properties or {}
+                    {%- if ('subject' not in message_properties) and ('subject' not in message_application_properties) %}
                     assert properties.get('subject') == '{{ messageid }}'
+                    {%- endif %}
                     # Verify message body is not empty
                     assert received.body is not None
+
+                {%- if message_properties %}
+                {%- for propname, prop in message_properties.items() if prop.value is defined %}
+                {%- set property_key = propname | lower %}
+                {%- if property_key in amqp_message_property_attributes %}
+                assert received.{{ amqp_message_property_attributes[property_key] }} == {{ protocol_option_expected_value(prop) }}
+                {%- endif %}
+                {%- endfor %}
+                {%- endif %}
+                {%- if message_application_properties %}
+                {%- for propname, prop in message_application_properties.items() if prop.value is defined %}
+                assert properties.get('{{ propname }}') == {{ protocol_option_expected_value(prop) }}
+                {%- endfor %}
+                {%- endif %}
         finally:
             producer.close()
     


### PR DESCRIPTION
## Summary
- generate Python AMQP producer parameters for protocoloptions.properties and protocoloptions.application_properties URI templates
- map AMQP properties.subject to qpid-proton Message.subject and declared application properties to Message.properties
- add fixture and regression coverage for issue #292

Fixes #292

## Tests
- python -m pytest test\py\test_python.py -k amqpproducer