### PR TITLE
Fix Python AMQP group annotations and time

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import os
 import tempfile
+import json
 import pytest
 
 project_root = os.path.abspath(
@@ -402,6 +403,17 @@ def _generate_amqp_producer_src(xreg_relpath="test/xreg/lightbulb-amqp.xreg.json
     return open(producer_files[0], encoding="utf-8").read()
 
 
+def _generate_amqp_producer_src_from_document(document):
+    """Generate the Python AMQP producer for an inline xRegistry document."""
+    with tempfile.NamedTemporaryFile("w", suffix=".xreg.json", delete=False, encoding="utf-8") as fp:
+        json.dump(document, fp)
+        manifest_path = fp.name
+    try:
+        return _generate_amqp_producer_src(manifest_path)
+    finally:
+        os.unlink(manifest_path)
+
+
 def _generate_mqtt_client_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
     """Generate the Python MQTT client for the given fixture and return the
     contents of the generated client.py as a string.
@@ -542,6 +554,88 @@ def test_amqpproducer_protocoloptions_message_annotations_codegen():
     assert "annotation_value = str(annotation_value)[:128]" in src
     assert 'annotations[symbol("x-opt-partition-key")] = annotation_value' in src
     assert "amqp_msg.annotations.update(annotations)" in src
+
+
+def test_amqpproducer_group_level_message_annotations_codegen():
+    """AMQP producer must merge messagegroup-level message_annotations into
+    CloudEvents messages and de-dupe placeholders already used by metadata.
+    """
+    src = _generate_amqp_producer_src_from_document({
+        "messagegroups": {
+            "Example.Amqp": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "AMQP/1.0",
+                "protocoloptions": {
+                    "message_annotations": {
+                        "x-opt-partition-key": {
+                            "type": "uritemplate",
+                            "value": "{spacecraft}"
+                        }
+                    }
+                },
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "AMQP/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"type": "uritemplate", "value": "{feedurl}"},
+                            "subject": {"type": "uritemplate", "value": "{spacecraft}"},
+                            "datacontenttype": {"value": "application/json"}
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}}
+                        }
+                    }
+                }
+            }
+        }
+    })
+    sig_start = src.index("def send_event(")
+    sig_end = src.index(") -> None:", sig_start)
+    send_signature = src[sig_start:sig_end]
+    assert send_signature.count("_spacecraft: str") == 1
+    assert 'annotation_value = "{spacecraft}".format(spacecraft=_spacecraft)' in src
+    assert 'annotations[symbol("x-opt-partition-key")] = annotation_value' in src
+
+
+def test_amqpproducer_time_uritemplate_sets_ce_and_creation_time():
+    """AMQP producer must not drop CloudEvents time URI templates and should
+    project parseable values onto AMQP properties.creation-time.
+    """
+    src = _generate_amqp_producer_src_from_document({
+        "messagegroups": {
+            "Example.Amqp": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "AMQP/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "AMQP/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"type": "uritemplate", "value": "{feedurl}"},
+                            "subject": {"type": "uritemplate", "value": "{spacecraft}"},
+                            "time": {"type": "uritemplate", "value": "{time_tag}"},
+                            "datacontenttype": {"value": "application/json"}
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}}
+                        }
+                    }
+                }
+            }
+        }
+    })
+    assert "_time_tag: str" in src
+    assert '"{time_tag}".format(time_tag=_time_tag)' in src
+    assert "None,  # Will be auto-generated" not in src
+    assert "amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))" in src
+    assert "amqp_msg.creation_time = amqp_creation_time" in src
 
 
 def test_mqttclient_body_is_bytes_not_str():

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -58,6 +58,7 @@ import json
 import threading
 import queue
 import concurrent.futures
+from datetime import datetime, timezone
 from urllib.parse import quote_plus
 from proton import Message, symbol
 from proton.utils import BlockingConnection
@@ -652,6 +653,23 @@ class {{ class_name }}:
         return payload
 
     @staticmethod
+    def _coerce_amqp_timestamp(value: typing.Any) -> typing.Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=timezone.utc)
+            return int(value.timestamp() * 1000)
+        if isinstance(value, (int, float)):
+            return int(value)
+        text = str(value)
+        normalized = text[:-1] + '+00:00' if text.endswith('Z') else text
+        try:
+            return int(datetime.fromisoformat(normalized).timestamp() * 1000)
+        except ValueError:
+            return None
+
+    @staticmethod
     def _ce_headers_to_amqp_properties(headers: typing.Mapping[str, typing.Any]) -> typing.Dict[str, typing.Any]:
         """Translate cloudevents-sdk HTTP-style headers (``ce-foo``) into the
         CloudEvents AMQP 1.0 Protocol Binding (v1.0.2 §3.1) form
@@ -676,10 +694,23 @@ class {{ class_name }}:
     {%- set messagename = messageid | pascal | strip_namespace %}
     {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
+    {%- set group_protocoloptions = messagegroup.protocoloptions if messagegroup.protocoloptions is defined and messagegroup.protocoloptions else {} %}
     {%- set protocoloptions = message.protocoloptions if message.protocoloptions is defined and message.protocoloptions else {} %}
-    {%- set message_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
-    {%- set message_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
-    {%- set message_annotations = protocoloptions['message_annotations'] if 'message_annotations' in protocoloptions else (protocoloptions['message-annotations'] if 'message-annotations' in protocoloptions else {}) %}
+    {%- set group_properties = group_protocoloptions['properties'] if 'properties' in group_protocoloptions else {} %}
+    {%- set local_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
+    {%- set group_application_properties = group_protocoloptions['application_properties'] if 'application_properties' in group_protocoloptions else (group_protocoloptions['application-properties'] if 'application-properties' in group_protocoloptions else {}) %}
+    {%- set local_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
+    {%- set group_annotations = group_protocoloptions['message_annotations'] if 'message_annotations' in group_protocoloptions else (group_protocoloptions['message-annotations'] if 'message-annotations' in group_protocoloptions else {}) %}
+    {%- set local_annotations = protocoloptions['message_annotations'] if 'message_annotations' in protocoloptions else (protocoloptions['message-annotations'] if 'message-annotations' in protocoloptions else {}) %}
+    {%- set message_properties = {} %}
+    {%- set _ = message_properties.update(group_properties) %}
+    {%- set _ = message_properties.update(local_properties) %}
+    {%- set message_application_properties = {} %}
+    {%- set _ = message_application_properties.update(group_application_properties) %}
+    {%- set _ = message_application_properties.update(local_application_properties) %}
+    {%- set message_annotations = {} %}
+    {%- set _ = message_annotations.update(group_annotations) %}
+    {%- set _ = message_annotations.update(local_annotations) %}
     {%- set ce_arg_names = namespace(items=[]) %}
     {%- if isCloudEvent %}
     {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
@@ -768,7 +799,16 @@ class {{ class_name }}:
             {%- if attrname == "id" %}
             str(uuid.uuid4()),
             {%- elif attrname == "time" %}
+            {%- if attribute.value %}
+            {%- if attribute.type == "uritemplate" %}
+            {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+            "{{ attribute.value }}"{% if phs %}.format({% for placeholder in phs %}{{ placeholder }}=_{{ placeholder | snake }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %},
+            {%- else %}
+            "{{ attribute.value }}",
+            {%- endif %}
+            {%- else %}
             None,  # Will be auto-generated
+            {%- endif %}
             {%- elif attrname == "datacontenttype" %}
             content_type,
             {%- elif attrname == "dataschema" %}
@@ -819,6 +859,12 @@ class {{ class_name }}:
         byte_data = self._serialize_payload(data, content_type)
         amqp_msg = Message(body=byte_data, inferred=True)
         amqp_msg.content_type = content_type
+        {%- endif %}
+
+        {%- if isCloudEvent %}
+        amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))
+        if amqp_creation_time is not None:
+            amqp_msg.creation_time = amqp_creation_time
         {%- endif %}
 
         {%- if message_properties %}

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -304,10 +304,23 @@ class Test{{ class_name }}:
     {%- set messagename = messageid | pascal | strip_namespace %}
     {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
+    {%- set group_protocoloptions = messagegroup.protocoloptions if messagegroup.protocoloptions is defined and messagegroup.protocoloptions else {} %}
     {%- set protocoloptions = message.protocoloptions if message.protocoloptions is defined and message.protocoloptions else {} %}
-    {%- set message_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
-    {%- set message_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
-    {%- set message_annotations = protocoloptions['message_annotations'] if 'message_annotations' in protocoloptions else (protocoloptions['message-annotations'] if 'message-annotations' in protocoloptions else {}) %}
+    {%- set group_properties = group_protocoloptions['properties'] if 'properties' in group_protocoloptions else {} %}
+    {%- set local_properties = protocoloptions['properties'] if 'properties' in protocoloptions else {} %}
+    {%- set group_application_properties = group_protocoloptions['application_properties'] if 'application_properties' in group_protocoloptions else (group_protocoloptions['application-properties'] if 'application-properties' in group_protocoloptions else {}) %}
+    {%- set local_application_properties = protocoloptions['application_properties'] if 'application_properties' in protocoloptions else (protocoloptions['application-properties'] if 'application-properties' in protocoloptions else {}) %}
+    {%- set group_annotations = group_protocoloptions['message_annotations'] if 'message_annotations' in group_protocoloptions else (group_protocoloptions['message-annotations'] if 'message-annotations' in group_protocoloptions else {}) %}
+    {%- set local_annotations = protocoloptions['message_annotations'] if 'message_annotations' in protocoloptions else (protocoloptions['message-annotations'] if 'message-annotations' in protocoloptions else {}) %}
+    {%- set message_properties = {} %}
+    {%- set _ = message_properties.update(group_properties) %}
+    {%- set _ = message_properties.update(local_properties) %}
+    {%- set message_application_properties = {} %}
+    {%- set _ = message_application_properties.update(group_application_properties) %}
+    {%- set _ = message_application_properties.update(local_application_properties) %}
+    {%- set message_annotations = {} %}
+    {%- set _ = message_annotations.update(group_annotations) %}
+    {%- set _ = message_annotations.update(local_annotations) %}
     
     def test_send_{{ messagename | snake }}(self, artemis_container):
         """Send and receive a {{ messagename }} message via ActiveMQ Artemis."""


### PR DESCRIPTION
## Summary
- merge messagegroup-level AMQP protocol options with per-message options in Python amqpproducer generation
- emit group-level `message_annotations` such as `x-opt-partition-key` on CloudEvents AMQP messages
- resolve CloudEvents `envelopemetadata.time` URI templates instead of forcing `None`
- set AMQP `creation_time` from parseable CloudEvents time values

Fixes #296
Fixes #297

## Tests
- python -m pytest test\py\test_python.py::test_amqpproducer_group_level_message_annotations_codegen test\py\test_python.py::test_amqpproducer_time_uritemplate_sets_ce_and_creation_time test\py\test_python.py::test_amqpproducer_protocoloptions_message_annotations_codegen
- python -m pytest test\py\test_python.py -k amqpproducer
- generated Python AMQP producer py_compile for lightbulb-amqp and custom CloudEvents/time/group-annotation repro