### PR TITLE
Fix Java AMQP tests for protocol option args

### DIFF
--- a/test/xreg/lightbulb-amqp.xreg.json
+++ b/test/xreg/lightbulb-amqp.xreg.json
@@ -16,6 +16,11 @@
                             }
                         },
                         "application_properties": {
+                            "subject": {
+                                "required": true,
+                                "value": "Fabrikam.Lumen.TurnedOn",
+                                "description": "Event raised when the bulb is turned on"
+                            },
                             "water_shortname": {
                                 "type": "uritemplate",
                                 "required": true,

--- a/xrcg/templates/java/amqpconsumer/src/main/java/{classdir}EventConsumer.java.jinja
+++ b/xrcg/templates/java/amqpconsumer/src/main/java/{classdir}EventConsumer.java.jinja
@@ -469,8 +469,12 @@ public class {{ class_name }} {
     
     {%- if uses_amqp_message %}
     private void dispatchAmqpMessage(Message<?> message, MessageContext context, Logger log) throws Exception {
-        // Extract subject from application properties
+        // Prefer the legacy static application-property subject when present;
+        // fall back to the AMQP properties subject for manifests that use it.
         Object subjectObj = message.property("subject");
+        if (subjectObj == null) {
+            subjectObj = message.subject();
+        }
         String subject = subjectObj != null ? subjectObj.toString() : null;
         
         log.info("Dispatching AMQP message with subject: " + subject);

--- a/xrcg/templates/java/amqpconsumer/src/test/java/{classdir}AmqpConsumerTest.java.jinja
+++ b/xrcg/templates/java/amqpconsumer/src/test/java/{classdir}AmqpConsumerTest.java.jinja
@@ -263,6 +263,9 @@ public class {{ class_name | strip_namespace }} {
             testMessage.messageId(UUID.randomUUID().toString());
             testMessage.contentType("application/json");
             {%- set protocolopts = message.get('protocoloptions', {}) %}
+            {%- if protocolopts.get('properties') and protocolopts.properties.get('subject') and protocolopts.properties.subject.get('value') %}
+            testMessage.subject("{{ protocolopts.properties.subject.value }}");
+            {%- endif %}
             {%- if protocolopts.get('application_properties') %}
             {%- for propname, propspec in protocolopts.application_properties.items() %}
             {%- if propspec.get('value') %}

--- a/xrcg/templates/java/amqpproducer/src/test/java/{classdir}AmqpProducerTest.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/test/java/{classdir}AmqpProducerTest.java.jinja
@@ -348,6 +348,28 @@ public class {{ class_name | strip_namespace }} {
             {%- endif -%}
             {%- endfor -%}
             {%- endif -%}
+            {%- if message.protocoloptions %}
+            {%- set protocoloptions = message.protocoloptions %}
+            {%- set message_annotations = protocoloptions["message_annotations"] if "message_annotations" in protocoloptions else (protocoloptions["message-annotations"] if "message-annotations" in protocoloptions else none) %}
+            {%- set delivery_annotations = protocoloptions["delivery_annotations"] if "delivery_annotations" in protocoloptions else (protocoloptions["delivery-annotations"] if "delivery-annotations" in protocoloptions else none) %}
+            {%- set application_properties = protocoloptions["application_properties"] if "application_properties" in protocoloptions else (protocoloptions["application-properties"] if "application-properties" in protocoloptions else none) %}
+            {%- set emitted = namespace(args=[]) %}
+            {%- for props in [protocoloptions.header if protocoloptions.header else none, protocoloptions.footer if protocoloptions.footer else none, message_annotations, delivery_annotations, protocoloptions.properties if protocoloptions.properties else none, application_properties] if props %}
+            {%- for propname, prop in props.items() %}
+            {%- if prop.type == "uritemplate" %}
+            {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+            {%- if placeholder not in emitted.args %}
+            , "test-{{ placeholder }}"
+            {%- set _ = emitted.args.append(placeholder) %}
+            {%- endif %}
+            {%- endfor %}
+            {%- elif prop.value is not defined and propname not in emitted.args %}
+            , "test-{{ propname }}"
+            {%- set _ = emitted.args.append(propname) %}
+            {%- endif %}
+            {%- endfor %}
+            {%- endfor %}
+            {%- endif %}
             {%- endif -%}
             );
         }


### PR DESCRIPTION
## Summary
- pass generated AMQP protocol option URI-template arguments from Java AMQP producer tests
- keep Java AMQP consumer dispatch compatible with static `application_properties.subject` while falling back to AMQP `properties.subject`
- restore a static application-property subject on the lightbulb AMQP fixture while retaining the dynamic AMQP subject and annotations coverage

Follow-up to #298.

## Tests
- `AMQP_BROKER=rabbitmq python -m pytest -v test/java/ -k amqp`
- `python -m pytest test/java/test_java.py::test_amqpproducer_lightbulb_amqp_java test/java/test_java.py::test_amqpconsumer_lightbulb_amqp_java`
- `python -m pytest test/py/test_python.py::test_amqpproducer_protocoloptions_application_properties_codegen test/py/test_python.py::test_amqpproducer_protocoloptions_message_annotations_codegen test/py/test_python.py::test_amqpproducer_group_level_message_annotations_codegen test/py/test_python.py::test_amqpproducer_time_uritemplate_sets_ce_and_creation_time`