### PR TITLE
Fix Python CloudEvents time handling across transports

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -835,6 +835,7 @@ def test_generated_py_cloudevents_time_normalizer_validates_rfc3339(style, entry
     )
     assert module._normalize_cloudevents_time(None) is None
     assert module._normalize_cloudevents_time(datetime(2024, 1, 2, 3, 4, 5)) == "2024-01-02T03:04:05Z"
+    assert module._normalize_cloudevents_time("2024-01-02T03:04:05.123456") == "2024-01-02T03:04:05.123456Z"
     assert module._normalize_cloudevents_time("2024-01-02t03:04:05z") == "2024-01-02T03:04:05Z"
     with pytest.raises(ValueError, match="RFC 3339"):
         module._normalize_cloudevents_time("2024-01-02")

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -6,6 +6,7 @@ import sys
 import os
 import tempfile
 import json
+from datetime import datetime
 import pytest
 
 project_root = os.path.abspath(
@@ -420,6 +421,75 @@ def _generate_amqp_producer_src_from_document(document):
         os.unlink(manifest_path)
 
 
+def _generate_python_entrypoint_from_document(document, style, entrypoint_name):
+    """Generate a Python entrypoint file from an inline xRegistry document."""
+    import glob
+    import uuid
+
+    with tempfile.NamedTemporaryFile("w", suffix=".xreg.json", delete=False, encoding="utf-8") as fp:
+        json.dump(document, fp)
+        manifest_path = fp.name
+    try:
+        tmpdirname = tempfile.mkdtemp()
+        projectname = f"test_{style}_{uuid.uuid4().hex[:8]}"
+        _generate_with_template_args(
+            manifest_path,
+            tmpdirname,
+            projectname,
+            style,
+            [],
+        )
+        entrypoint_files = glob.glob(os.path.join(tmpdirname, "**", entrypoint_name), recursive=True)
+        assert entrypoint_files, f"no {entrypoint_name} emitted under {tmpdirname}"
+        return tmpdirname, entrypoint_files[0]
+    finally:
+        os.unlink(manifest_path)
+
+
+def _generate_kafka_producer_src_from_document(document):
+    """Generate the Python Kafka producer for an inline xRegistry document."""
+    _, producer_file = _generate_python_entrypoint_from_document(document, "kafkaproducer", "producer.py")
+    return open(producer_file, encoding="utf-8").read()
+
+
+def _generate_mqtt_client_src_from_document(document):
+    """Generate the Python MQTT client for an inline xRegistry document."""
+    _, client_file = _generate_python_entrypoint_from_document(document, "mqttclient", "client.py")
+    return open(client_file, encoding="utf-8").read()
+
+
+def _load_generated_python_module_from_document(document, style, entrypoint_name):
+    """Load the generated CloudEvents time normalizer from emitted source."""
+    import ast
+    import types
+
+    _, entrypoint_file = _generate_python_entrypoint_from_document(document, style, entrypoint_name)
+    entrypoint_src = open(entrypoint_file, encoding="utf-8").read()
+    parsed = ast.parse(entrypoint_src, filename=entrypoint_file)
+    selected_nodes = []
+    for node in parsed.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "_RFC3339_TIMESTAMP_PATTERN"
+            for target in node.targets
+        ):
+            selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name == "_normalize_cloudevents_time":
+            selected_nodes.append(node)
+    helper_module = ast.Module(
+        body=[
+            ast.Import(names=[ast.alias(name="re")]),
+            ast.Import(names=[ast.alias(name="typing")]),
+            ast.ImportFrom(module="datetime", names=[ast.alias(name="datetime"), ast.alias(name="timezone")], level=0),
+            *selected_nodes,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(helper_module)
+    namespace = {}
+    exec(compile(helper_module, entrypoint_file, "exec"), namespace)
+    return types.SimpleNamespace(**namespace)
+
+
 def _generate_mqtt_client_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
     """Generate the Python MQTT client for the given fixture and return the
     contents of the generated client.py as a string.
@@ -456,6 +526,92 @@ def _generate_mqtt_client_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):
 #      ``inferred=True`` so the body becomes an AMQP binary section.
 # ---------------------------------------------------------------------------
 
+
+def _build_kafka_time_document():
+    return {
+        "messagegroups": {
+            "Example.Kafka": {
+                "envelope": "CloudEvents/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"value": "urn:test"},
+                            "time": {"type": "uritemplate", "value": "{event_time}"},
+                            "datacontenttype": {"value": "application/json"},
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+def _build_amqp_time_document():
+    return {
+        "messagegroups": {
+            "Example.Amqp": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "AMQP/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "AMQP/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"type": "uritemplate", "value": "{feedurl}"},
+                            "subject": {"type": "uritemplate", "value": "{spacecraft}"},
+                            "time": {"type": "uritemplate", "value": "{time_tag}"},
+                            "datacontenttype": {"value": "application/json"}
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def _build_mqtt_time_document():
+    return {
+        "messagegroups": {
+            "Example.Mqtt": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "MQTT/5.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "MQTT/5.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"value": "urn:test"},
+                            "time": {"type": "uritemplate", "value": "{event_time}"},
+                            "datacontenttype": {"value": "application/json"},
+                        },
+                        "protocoloptions": {
+                            "topic_name": "example/{event_time}"
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
 def test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix():
     """CloudEvents AMQP §3.1: application-properties prefix MUST be
     ``cloudEvents:``. The legacy ``ce-`` HTTP-binding prefix MUST NOT
@@ -476,6 +632,15 @@ def test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix():
         "producer.py must not assign the raw cloudevents-sdk headers "
         "dict (which has 'ce-' prefixes) to amqp_msg.properties"
     )
+
+
+def test_kafkaproducer_time_uritemplate_is_normalized_before_cloudevent_creation():
+    """Kafka producer must normalize mapped CloudEvents time before sending."""
+    src = _generate_kafka_producer_src_from_document(_build_kafka_time_document())
+    assert "def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:" in src
+    assert "if 'time' in attributes:" in src
+    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
+    assert "del attributes['time']" in src
 
 
 def test_amqpproducer_body_is_bytes_with_inferred_true():
@@ -611,35 +776,11 @@ def test_amqpproducer_time_uritemplate_sets_ce_and_creation_time():
     """AMQP producer must not drop CloudEvents time URI templates and should
     project parseable values onto AMQP properties.creation-time.
     """
-    src = _generate_amqp_producer_src_from_document({
-        "messagegroups": {
-            "Example.Amqp": {
-                "envelope": "CloudEvents/1.0",
-                "protocol": "AMQP/1.0",
-                "messages": {
-                    "Example.Event": {
-                        "envelope": "CloudEvents/1.0",
-                        "protocol": "AMQP/1.0",
-                        "envelopemetadata": {
-                            "type": {"value": "Example.Event"},
-                            "source": {"type": "uritemplate", "value": "{feedurl}"},
-                            "subject": {"type": "uritemplate", "value": "{spacecraft}"},
-                            "time": {"type": "uritemplate", "value": "{time_tag}"},
-                            "datacontenttype": {"value": "application/json"}
-                        },
-                        "dataschemaformat": "JsonSchema/draft-07",
-                        "dataschema": {
-                            "type": "object",
-                            "properties": {"value": {"type": "string"}}
-                        }
-                    }
-                }
-            }
-        }
-    })
+    src = _generate_amqp_producer_src_from_document(_build_amqp_time_document())
     assert "_time_tag: str" in src
     assert '"{time_tag}".format(time_tag=_time_tag)' in src
     assert "None,  # Will be auto-generated" not in src
+    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
     assert "amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))" in src
     assert "amqp_msg.creation_time = amqp_creation_time" in src
 
@@ -669,6 +810,34 @@ def test_mqttclient_body_is_bytes_not_str():
         "client.py must coerce str payload to bytes before publish so the "
         "wire representation matches the declared content-type byte-for-byte"
     )
+
+
+def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
+    """MQTT client must normalize mapped CloudEvents time before publishing."""
+    src = _generate_mqtt_client_src_from_document(_build_mqtt_time_document())
+    assert "def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:" in src
+    assert "if 'time' in attributes:" in src
+    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
+    assert "del attributes['time']" in src
+
+
+@pytest.mark.parametrize("style,entrypoint_name,document_builder", [
+    ("kafkaproducer", "producer.py", _build_kafka_time_document),
+    ("amqpproducer", "producer.py", _build_amqp_time_document),
+    ("mqttclient", "client.py", _build_mqtt_time_document),
+])
+def test_generated_py_cloudevents_time_normalizer_validates_rfc3339(style, entrypoint_name, document_builder):
+    """Generated Python CloudEvents helpers must validate and normalize time."""
+    module = _load_generated_python_module_from_document(
+        document_builder(),
+        style,
+        entrypoint_name,
+    )
+    assert module._normalize_cloudevents_time(None) is None
+    assert module._normalize_cloudevents_time(datetime(2024, 1, 2, 3, 4, 5)) == "2024-01-02T03:04:05Z"
+    assert module._normalize_cloudevents_time("2024-01-02t03:04:05z") == "2024-01-02T03:04:05Z"
+    with pytest.raises(ValueError, match="RFC 3339"):
+        module._normalize_cloudevents_time("2024-01-02")
 
 
 def _generate_eh_producer_src(xreg_relpath="test/xreg/lightbulb.xreg.json"):

--- a/xrcg/templates/py/_common/cloudevents.jinja.include
+++ b/xrcg/templates/py/_common/cloudevents.jinja.include
@@ -7,6 +7,41 @@
 {{- (attrname in ['source', 'type'] and attrname not in message.envelopemetadata) -}}
 {%- endmacro -%}
 
+{%- macro DeclareRfc3339TimeNormalizer() -%}
+_RFC3339_TIMESTAMP_PATTERN = re.compile(
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$'
+)
+
+
+def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
+    """Validate and normalize CloudEvents ``time`` to RFC 3339."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace('+00:00', 'Z')
+    text = str(value).strip()
+    if not text:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    if not _RFC3339_TIMESTAMP_PATTERN.fullmatch(text):
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    normalized = text
+    if normalized[10] == 't':
+        normalized = normalized[:10] + 'T' + normalized[11:]
+    if normalized.endswith('z'):
+        normalized = normalized[:-1] + 'Z'
+    if normalized.endswith('Z'):
+        normalized = normalized[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+    return parsed.isoformat().replace('+00:00', 'Z')
+{%- endmacro -%}
+
 # Generates a list of arguments for "send" methods that correspond to placeholders in uritemplates
 {%- macro DeclareUriTemplateArguments(message) -%}
 {%- for attrname in message.envelopemetadata if attrname not in ["datacontenttype", "dataschema"] -%}

--- a/xrcg/templates/py/_common/cloudevents.jinja.include
+++ b/xrcg/templates/py/_common/cloudevents.jinja.include
@@ -9,7 +9,7 @@
 
 {%- macro DeclareRfc3339TimeNormalizer() -%}
 _RFC3339_TIMESTAMP_PATTERN = re.compile(
-    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})$'
+    r'^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?$'
 )
 
 
@@ -38,7 +38,7 @@ def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
     except ValueError as exc:
         raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp") from exc
     if parsed.tzinfo is None:
-        raise ValueError("CloudEvents 'time' must be an RFC 3339 timestamp")
+        parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.isoformat().replace('+00:00', 'Z')
 {%- endmacro -%}
 

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -55,6 +55,7 @@ import sys
 import typing
 import uuid
 import json
+import re
 import threading
 import queue
 import concurrent.futures
@@ -64,6 +65,8 @@ from proton import Message, symbol
 from proton.utils import BlockingConnection
 from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_binary, to_structured
+
+{{ cloudEvents.DeclareRfc3339TimeNormalizer() }}
 {%- if _azure_cbs_target %}
 
 # --- Azure CBS support (azure_cbs_target={{ _azure_cbs_target }}) ---
@@ -825,6 +828,12 @@ class {{ class_name }}:
             {%- endif %}
         {%- endfor %}
         }
+        if 'time' in attributes:
+            normalized_time = _normalize_cloudevents_time(attributes['time'])
+            if normalized_time is None:
+                del attributes['time']
+            else:
+                attributes['time'] = normalized_time
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -1,14 +1,18 @@
 {%- import "util.include.jinja" as util -%}
+{%- import "cloudevents.jinja.include" as cloudEvents -%}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import sys
 import json
+import re
 import uuid
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 from confluent_kafka import Producer, KafkaException, Message
 from cloudevents.kafka import to_binary, to_structured, KafkaMessage
 from cloudevents.http import CloudEvent
+
+{{ cloudEvents.DeclareRfc3339TimeNormalizer() }}
 
 {%- set messagegroups = root.messagegroups %}
 {%- set imports = [] %}
@@ -186,6 +190,12 @@ class {{ class_name }}:
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
+        if 'time' in attributes:
+            normalized_time = _normalize_cloudevents_time(attributes['time'])
+            if normalized_time is None:
+                del attributes['time']
+            else:
+                attributes['time'] = normalized_time
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: {% if data_type != "object"%}json.loads(x.to_json()){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -1,4 +1,5 @@
 {%- import "util.include.jinja" as util -%}
+{%- import "cloudevents.jinja.include" as cloudEvents -%}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import json
@@ -6,6 +7,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
     # paho-mqtt 2.x exposes MQTT5 Properties for the PUBLISH packet type.
@@ -40,6 +42,8 @@ import {{ data_project_name | dotunderscore | lower }}
 
 # URI template regex pattern
 _URI_TEMPLATE_PATTERN = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
+{{ cloudEvents.DeclareRfc3339TimeNormalizer() }}
 
 
 def _topic_to_mqtt_wildcard(topic: str) -> str:
@@ -516,6 +520,12 @@ class {{ class_name }}(_ClientBase):
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
+        if 'time' in attributes:
+            normalized_time = _normalize_cloudevents_time(attributes['time'])
+            if normalized_time is None:
+                del attributes['time']
+            else:
+                attributes['time'] = normalized_time
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's

--- a/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
+++ b/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
@@ -6,6 +6,7 @@ import sys
 import pytest
 import pytest_asyncio
 import asyncio
+import datetime
 import time
 import paho.mqtt.client as mqtt
 from testcontainers.core.container import DockerContainer
@@ -148,11 +149,19 @@ async def test_{{groupName}}_{{messagename.split('.')[-1]}}_py(mosquitto_broker)
             {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             {%- if phs %}
             {%- for placeholder in phs %}
+            {%- if attrname == "time" %}
+            {{ placeholder | snake }}=datetime.datetime.now().isoformat(),
+            {%- else %}
             {{ placeholder | snake }}=f"test_{{placeholder}}_{i}",
+            {%- endif %}
             {%- endfor %}
             {%- endif %}
             {%- elif not attribute.value %}
+            {%- if attrname == "time" %}
+            _{{ attrname | snake }}=datetime.datetime.now().isoformat(),
+            {%- else %}
             _{{ attrname | snake }}=f"test_{{attrname}}_{i}",
+            {%- endif %}
             {%- endif %}
             {%- endfor %}
             data=test_data,


### PR DESCRIPTION
## Summary
- normalize and validate mapped CloudEvents time in the Python Kafka, AMQP, and MQTT generators
- keep auto-generated time behavior when a mapping resolves to None
- add regression coverage for generated RFC 3339 normalization

Closes #367