### PR TITLE
Fix Python AMQP password-mode sender timeouts on Artemis

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -403,8 +403,8 @@ def test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender():
     assert "sender_options = AtMostOnce() if self.username and self.password else None" in src
     assert "self._sender = self._connection.create_sender(self.address, options=sender_options)" in src
     assert "self._sender.send(amqp_msg, timeout=timeout)" in src
-    assert "lambda: self._sender.link.queued == 0" in src
-    assert 'msg=f"Flushing sender {self._sender.link.name}"' in src
+    assert "self._connection.conn.transport.pending() == 0" in src
+    assert 'msg=f"Flushing sender {self._sender.link.name} transport"' in src
     assert "self._send_via_blocking_sender(amqp_msg)" in src
     assert "self._connection.create_sender(self.address)\n" not in src
     assert "BlockingConnection(connection_url, timeout=30)" not in src

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -392,6 +392,18 @@ def test_amqpproducer_no_azure_cbs_has_no_azure_deps():
     assert "azure-identity" not in pyp
 
 
+def test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender():
+    """Password-mode AMQP producers must use the Artemis-safe blocking sender path."""
+    src = _generate_amqp_producer_src("test/xreg/lightbulb-amqp.xreg.json")
+    assert "from proton.reactor import AtMostOnce" in src
+    assert "def _init_blocking_sender(self) -> None:" in src
+    assert "connection_timeout = 120 if self.username and self.password else 30" in src
+    assert "sender_options = AtMostOnce() if self.username and self.password else None" in src
+    assert "self._sender = self._connection.create_sender(self.address, options=sender_options)" in src
+    assert "self._connection.create_sender(self.address)\n" not in src
+    assert "BlockingConnection(connection_url, timeout=30)" not in src
+
+
 def _generate_amqp_producer_src(xreg_relpath="test/xreg/lightbulb-amqp.xreg.json", template_args=None):
     """Generate the Python AMQP producer for the given fixture and return
     the contents of the generated producer.py as a string.

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -397,9 +397,15 @@ def test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender():
     src = _generate_amqp_producer_src("test/xreg/lightbulb-amqp.xreg.json")
     assert "from proton.reactor import AtMostOnce" in src
     assert "def _init_blocking_sender(self) -> None:" in src
+    assert "self._blocking_sender_is_presettled = sender_options is not None" in src
+    assert "def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:" in src
     assert "connection_timeout = 120 if self.username and self.password else 30" in src
     assert "sender_options = AtMostOnce() if self.username and self.password else None" in src
     assert "self._sender = self._connection.create_sender(self.address, options=sender_options)" in src
+    assert "self._sender.send(amqp_msg, timeout=timeout)" in src
+    assert "lambda: self._sender.link.queued == 0" in src
+    assert 'msg=f"Flushing sender {self._sender.link.name}"' in src
+    assert "self._send_via_blocking_sender(amqp_msg)" in src
     assert "self._connection.create_sender(self.address)\n" not in src
     assert "BlockingConnection(connection_url, timeout=30)" not in src
 

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -62,6 +62,7 @@ import concurrent.futures
 from datetime import datetime, timezone
 from urllib.parse import quote_plus
 from proton import Message, symbol
+from proton.reactor import AtMostOnce
 from proton.utils import BlockingConnection
 from cloudevents.http import CloudEvent
 from cloudevents.conversion import to_binary, to_structured
@@ -557,13 +558,9 @@ class {{ class_name }}:
         if self._cbs_enabled:
             self._init_reactor()
         else:
-            connection_url = self._build_connection_url()
-            self._connection = BlockingConnection(connection_url, timeout=30)
-            self._sender = self._connection.create_sender(self.address)
+            self._init_blocking_sender()
         {%- else %}
-        connection_url = self._build_connection_url()
-        self._connection = BlockingConnection(connection_url, timeout=30)
-        self._sender = self._connection.create_sender(self.address)
+        self._init_blocking_sender()
         {%- endif %}
     {%- if _azure_cbs_target %}
 
@@ -629,6 +626,15 @@ class {{ class_name }}:
         self._send_queue.put((amqp_msg, fut))
         fut.result(timeout=timeout)
     {%- endif %}
+
+    def _init_blocking_sender(self) -> None:
+        connection_url = self._build_connection_url()
+        connection_timeout = 120 if self.username and self.password else 30
+        # Artemis-class brokers can stall unsettled BlockingSender sends on
+        # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
+        sender_options = AtMostOnce() if self.username and self.password else None
+        self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
+        self._sender = self._connection.create_sender(self.address, options=sender_options)
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -633,8 +633,18 @@ class {{ class_name }}:
         # Artemis-class brokers can stall unsettled BlockingSender sends on
         # SASL PLAIN links; a pre-settled sender avoids the timeout loop.
         sender_options = AtMostOnce() if self.username and self.password else None
+        self._blocking_sender_is_presettled = sender_options is not None
         self._connection = BlockingConnection(connection_url, timeout=connection_timeout)
         self._sender = self._connection.create_sender(self.address, options=sender_options)
+
+    def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
+        self._sender.send(amqp_msg, timeout=timeout)
+        if self._blocking_sender_is_presettled:
+            self._connection.wait(
+                lambda: self._sender.link.queued == 0,
+                msg=f"Flushing sender {self._sender.link.name}",
+                timeout=timeout,
+            )
     
     def _build_connection_url(self) -> str:
         if self.username and self.password:
@@ -922,9 +932,9 @@ class {{ class_name }}:
         if getattr(self, "_handler", None) is not None:
             self._send_via_reactor(amqp_msg)
         else:
-            self._sender.send(amqp_msg)
+            self._send_via_blocking_sender(amqp_msg)
         {%- else %}
-        self._sender.send(amqp_msg)
+        self._send_via_blocking_sender(amqp_msg)
         {%- endif %}
     
     def send_{{ messagename | snake }}_batch(self,

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -640,9 +640,14 @@ class {{ class_name }}:
     def _send_via_blocking_sender(self, amqp_msg: Message, timeout: float = 30.0) -> None:
         self._sender.send(amqp_msg, timeout=timeout)
         if self._blocking_sender_is_presettled:
+            # BlockingSender.send() returns immediately for pre-settled
+            # deliveries, so wait until Proton has flushed all pending bytes.
             self._connection.wait(
-                lambda: self._sender.link.queued == 0,
-                msg=f"Flushing sender {self._sender.link.name}",
+                lambda: (
+                    self._connection.conn.transport is not None and
+                    self._connection.conn.transport.pending() == 0
+                ),
+                msg=f"Flushing sender {self._sender.link.name} transport",
                 timeout=timeout,
             )
     


### PR DESCRIPTION
## Summary
- use a dedicated blocking-sender initializer for Python AMQP producers
- widen the password-mode connection timeout and apply AtMostOnce() only for the username/password sender path
- add regression coverage for the generated Artemis-safe sender configuration

## Testing
- pytest test\\py\\test_python.py::test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender test\\py\\test_python.py::test_amqpproducer_azure_cbs_codegen test\\py\\test_python.py::test_amqpproducer_no_azure_cbs_has_no_azure_deps

Closes #369