### PR TITLE
Add explicit Python CloudEvents time override

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -491,7 +491,10 @@ def _load_generated_python_module_from_document(document, style, entrypoint_name
             for target in node.targets
         ):
             selected_nodes.append(node)
-        elif isinstance(node, ast.FunctionDef) and node.name == "_normalize_cloudevents_time":
+        elif isinstance(node, ast.FunctionDef) and node.name in {
+            "_normalize_cloudevents_time",
+            "_resolve_cloudevents_time",
+        }:
             selected_nodes.append(node)
     helper_module = ast.Module(
         body=[
@@ -653,12 +656,12 @@ def test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix():
 
 
 def test_kafkaproducer_time_uritemplate_is_normalized_before_cloudevent_creation():
-    """Kafka producer must normalize mapped CloudEvents time before sending."""
+    """Kafka producer must expose an explicit time override on send."""
     src = _generate_kafka_producer_src_from_document(_build_kafka_time_document())
-    assert "def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:" in src
-    assert "if 'time' in attributes:" in src
-    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
-    assert "del attributes['time']" in src
+    assert "def _resolve_cloudevents_time(" in src
+    assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert "_event_time : str" not in src
+    assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
 def test_amqpproducer_body_is_bytes_with_inferred_true():
@@ -791,14 +794,12 @@ def test_amqpproducer_group_level_message_annotations_codegen():
 
 
 def test_amqpproducer_time_uritemplate_sets_ce_and_creation_time():
-    """AMQP producer must not drop CloudEvents time URI templates and should
-    project parseable values onto AMQP properties.creation-time.
-    """
+    """AMQP producer must expose an explicit time override and project it to creation_time."""
     src = _generate_amqp_producer_src_from_document(_build_amqp_time_document())
-    assert "_time_tag: str" in src
-    assert '"{time_tag}".format(time_tag=_time_tag)' in src
-    assert "None,  # Will be auto-generated" not in src
-    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
+    assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert "_time_tag: str" not in src
+    assert '"{time_tag}".format(time_tag=_time_tag)' not in src
+    assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
     assert "amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))" in src
     assert "amqp_msg.creation_time = amqp_creation_time" in src
 
@@ -831,12 +832,11 @@ def test_mqttclient_body_is_bytes_not_str():
 
 
 def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
-    """MQTT client must normalize mapped CloudEvents time before publishing."""
+    """MQTT client must expose an explicit time override on publish."""
     src = _generate_mqtt_client_src_from_document(_build_mqtt_time_document())
-    assert "def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:" in src
-    assert "if 'time' in attributes:" in src
-    assert "normalized_time = _normalize_cloudevents_time(attributes['time'])" in src
-    assert "del attributes['time']" in src
+    assert "def _resolve_cloudevents_time(" in src
+    assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
 @pytest.mark.parametrize("style,entrypoint_name,document_builder", [
@@ -844,8 +844,8 @@ def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
     ("amqpproducer", "producer.py", _build_amqp_time_document),
     ("mqttclient", "client.py", _build_mqtt_time_document),
 ])
-def test_generated_py_cloudevents_time_normalizer_validates_rfc3339(style, entrypoint_name, document_builder):
-    """Generated Python CloudEvents helpers must validate and normalize time."""
+def test_generated_py_cloudevents_time_helpers_validate_and_resolve(style, entrypoint_name, document_builder):
+    """Generated Python CloudEvents helpers must validate and resolve time values."""
     module = _load_generated_python_module_from_document(
         document_builder(),
         style,
@@ -855,6 +855,9 @@ def test_generated_py_cloudevents_time_normalizer_validates_rfc3339(style, entry
     assert module._normalize_cloudevents_time(datetime(2024, 1, 2, 3, 4, 5)) == "2024-01-02T03:04:05Z"
     assert module._normalize_cloudevents_time("2024-01-02T03:04:05.123456") == "2024-01-02T03:04:05.123456Z"
     assert module._normalize_cloudevents_time("2024-01-02t03:04:05z") == "2024-01-02T03:04:05Z"
+    assert module._resolve_cloudevents_time(None, "2024-01-02T03:04:05.123456") == "2024-01-02T03:04:05.123456Z"
+    assert module._resolve_cloudevents_time("2024-01-02t03:04:05z", "2024-01-01T00:00:00Z") == "2024-01-02T03:04:05Z"
+    assert module._resolve_cloudevents_time(None, None).endswith("Z")
     with pytest.raises(ValueError, match="RFC 3339"):
         module._normalize_cloudevents_time("2024-01-02")
 
@@ -925,6 +928,14 @@ def test_ehproducer_body_is_bytes_not_str():
     )
 
 
+def test_ehproducer_exposes_time_override_argument():
+    """Event Hubs producer must expose a dedicated CloudEvents time override."""
+    src = _generate_eh_producer_src("test/xreg/lightbulb.xreg.json")
+    assert "def _resolve_cloudevents_time(" in src
+    assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
+
+
 def test_sbproducer_emits_cloudevents_prefix():
     """Service Bus producer already maps to 'cloudEvents:' — guard the
     mapping against regressions.
@@ -950,3 +961,11 @@ def test_sbproducer_body_is_bytes_not_str():
         "sbproducer must coerce cloudevents-sdk body str to bytes before "
         "constructing ServiceBusMessage"
     )
+
+
+def test_sbproducer_exposes_time_override_argument():
+    """Service Bus producer must expose a dedicated CloudEvents time override."""
+    src = _generate_sb_producer_src("test/xreg/lightbulb.xreg.json")
+    assert "def _resolve_cloudevents_time(" in src
+    assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -476,6 +476,18 @@ def _generate_mqtt_client_src_from_document(document):
     return open(client_file, encoding="utf-8").read()
 
 
+def _generate_eh_producer_src_from_document(document):
+    """Generate the Python Event Hubs producer for an inline xRegistry document."""
+    _, producer_file = _generate_python_entrypoint_from_document(document, "ehproducer", "producer.py")
+    return open(producer_file, encoding="utf-8").read()
+
+
+def _generate_sb_producer_src_from_document(document):
+    """Generate the Python Service Bus producer for an inline xRegistry document."""
+    _, producer_file = _generate_python_entrypoint_from_document(document, "sbproducer", "producer.py")
+    return open(producer_file, encoding="utf-8").read()
+
+
 def _load_generated_python_module_from_document(document, style, entrypoint_name):
     """Load the generated CloudEvents time normalizer from emitted source."""
     import ast
@@ -620,7 +632,58 @@ def _build_mqtt_time_document():
                             "datacontenttype": {"value": "application/json"},
                         },
                         "protocoloptions": {
-                            "topic_name": "example/{event_time}"
+                            "topic_name": "example/events"
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+ 
+ 
+def _build_eh_time_document():
+    return {
+        "messagegroups": {
+            "Example.Eh": {
+                "envelope": "CloudEvents/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"value": "urn:test"},
+                            "time": {"type": "uritemplate", "value": "{time_tag}"},
+                            "datacontenttype": {"value": "application/json"},
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+def _build_sb_time_document():
+    return {
+        "messagegroups": {
+            "Example.Sb": {
+                "envelope": "CloudEvents/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"value": "urn:test"},
+                            "time": {"type": "uritemplate", "value": "{time_tag}"},
+                            "datacontenttype": {"value": "application/json"},
                         },
                         "dataschemaformat": "JsonSchema/draft-07",
                         "dataschema": {
@@ -656,11 +719,12 @@ def test_amqpproducer_emits_cloudevents_prefix_not_ce_prefix():
 
 
 def test_kafkaproducer_time_uritemplate_is_normalized_before_cloudevent_creation():
-    """Kafka producer must expose an explicit time override on send."""
+    """Kafka producer must expose `_time` while still accepting legacy time placeholders."""
     src = _generate_kafka_producer_src_from_document(_build_kafka_time_document())
     assert "def _resolve_cloudevents_time(" in src
     assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
-    assert "_event_time : str" not in src
+    assert "_event_time: typing.Optional[str] = None" in src
+    assert '"{event_time}".format(event_time=_event_time)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
@@ -794,11 +858,11 @@ def test_amqpproducer_group_level_message_annotations_codegen():
 
 
 def test_amqpproducer_time_uritemplate_sets_ce_and_creation_time():
-    """AMQP producer must expose an explicit time override and project it to creation_time."""
+    """AMQP producer must keep legacy time placeholders and project time to creation_time."""
     src = _generate_amqp_producer_src_from_document(_build_amqp_time_document())
     assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
-    assert "_time_tag: str" not in src
-    assert '"{time_tag}".format(time_tag=_time_tag)' not in src
+    assert "_time_tag: typing.Optional[str] = None" in src
+    assert '"{time_tag}".format(time_tag=_time_tag)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
     assert "amqp_creation_time = self._coerce_amqp_timestamp(attributes.get('time'))" in src
     assert "amqp_msg.creation_time = amqp_creation_time" in src
@@ -832,10 +896,12 @@ def test_mqttclient_body_is_bytes_not_str():
 
 
 def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
-    """MQTT client must expose an explicit time override on publish."""
+    """MQTT client must expose `_time` while still accepting legacy time placeholders."""
     src = _generate_mqtt_client_src_from_document(_build_mqtt_time_document())
     assert "def _resolve_cloudevents_time(" in src
     assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert "event_time: Optional[str] = None" in src
+    assert '"{event_time}".format(event_time=event_time)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
@@ -929,10 +995,12 @@ def test_ehproducer_body_is_bytes_not_str():
 
 
 def test_ehproducer_exposes_time_override_argument():
-    """Event Hubs producer must expose a dedicated CloudEvents time override."""
-    src = _generate_eh_producer_src("test/xreg/lightbulb.xreg.json")
+    """Event Hubs producer must expose `_time` while preserving legacy placeholders."""
+    src = _generate_eh_producer_src_from_document(_build_eh_time_document())
     assert "def _resolve_cloudevents_time(" in src
     assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert "_time_tag: typing.Optional[str] = None" in src
+    assert '"{time_tag}".format(time_tag=_time_tag)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
@@ -964,8 +1032,10 @@ def test_sbproducer_body_is_bytes_not_str():
 
 
 def test_sbproducer_exposes_time_override_argument():
-    """Service Bus producer must expose a dedicated CloudEvents time override."""
-    src = _generate_sb_producer_src("test/xreg/lightbulb.xreg.json")
+    """Service Bus producer must expose `_time` while preserving legacy placeholders."""
+    src = _generate_sb_producer_src_from_document(_build_sb_time_document())
     assert "def _resolve_cloudevents_time(" in src
     assert "_time: typing.Optional[typing.Union[str, datetime]] = None" in src
+    assert "_time_tag: typing.Optional[str] = None" in src
+    assert '"{time_tag}".format(time_tag=_time_tag)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src

--- a/xrcg/templates/py/_common/cloudevents.jinja.include
+++ b/xrcg/templates/py/_common/cloudevents.jinja.include
@@ -40,6 +40,18 @@ def _normalize_cloudevents_time(value: typing.Any) -> typing.Optional[str]:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.isoformat().replace('+00:00', 'Z')
+
+
+def _resolve_cloudevents_time(
+    override: typing.Any = None,
+    fallback: typing.Any = None,
+) -> str:
+    """Resolve CloudEvents ``time`` from override, fallback, or current UTC."""
+    if override is not None:
+        return _normalize_cloudevents_time(override)
+    if fallback is not None:
+        return _normalize_cloudevents_time(fallback)
+    return _normalize_cloudevents_time(datetime.now(timezone.utc))
 {%- endmacro -%}
 
 # Generates a list of arguments for "send" methods that correspond to placeholders in uritemplates

--- a/xrcg/templates/py/_common/cloudevents.jinja.include
+++ b/xrcg/templates/py/_common/cloudevents.jinja.include
@@ -54,6 +54,21 @@ def _resolve_cloudevents_time(
     return _normalize_cloudevents_time(datetime.now(timezone.utc))
 {%- endmacro -%}
 
+{%- macro RenderLegacyTimeFallback(attribute, placeholder_prefix) -%}
+{%- if attribute.value and attribute.type == "uritemplate" -%}
+{%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+{%- if phs -%}
+("{{ attribute.value }}".format({% for placeholder in phs %}{{ placeholder }}={{ placeholder_prefix }}{{ placeholder | snake }}{% if not loop.last %}, {% endif %}{% endfor %}) if {% for placeholder in phs %}{{ placeholder_prefix }}{{ placeholder | snake }} is not None{% if not loop.last %} and {% endif %}{% endfor %} else None)
+{%- else -%}
+"{{ attribute.value }}"
+{%- endif -%}
+{%- elif attribute.value and attribute.type != "uritemplate" -%}
+"{{ attribute.value }}"
+{%- else -%}
+None
+{%- endif -%}
+{%- endmacro -%}
+
 # Generates a list of arguments for "send" methods that correspond to placeholders in uritemplates
 {%- macro DeclareUriTemplateArguments(message) -%}
 {%- for attrname in message.envelopemetadata if attrname not in ["datacontenttype", "dataschema"] -%}

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -740,7 +740,7 @@ class {{ class_name }}:
     {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
     {%- set _ = ce_arg_names.items.append(attrname | snake) %}
     {%- endfor %}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
     {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
     {%- set argname = placeholder | snake %}
     {%- if argname not in ce_arg_names.items %}
@@ -773,7 +773,7 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
         _{{ attrname }}: str,
         {%- endfor %}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
         _{{ placeholder | snake }}: str,
         {%- endfor %}
@@ -785,6 +785,7 @@ class {{ class_name }}:
         {%- for argname in protocol_option_arg_names.items %}
         _{{ argname }}: str,
         {%- endfor %}
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send the `{{ messageid }}` message
@@ -797,7 +798,7 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
             _{{ attrname }} (str): CloudEvents required attribute '{{ attrname }}'
         {%- endfor %}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }} (str): Value for placeholder {{ placeholder }} in attribute {{ attrname }}
         {%- endfor %}
@@ -809,6 +810,7 @@ class {{ class_name }}:
         {%- for argname in protocol_option_arg_names.items %}
             _{{ argname }} (str): Value for AMQP protocol option placeholder {{ argname }}
         {%- endfor %}
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data ({{ type_name }}): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
         """
@@ -823,15 +825,10 @@ class {{ class_name }}:
             {%- if attrname == "id" %}
             str(uuid.uuid4()),
             {%- elif attrname == "time" %}
-            {%- if attribute.value %}
-            {%- if attribute.type == "uritemplate" %}
-            {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
-            "{{ attribute.value }}"{% if phs %}.format({% for placeholder in phs %}{{ placeholder }}=_{{ placeholder | snake }}{% if not loop.last %}, {% endif %}{% endfor %}){% endif %},
-            {%- else %}
+            {%- if attribute.value and attribute.type != "uritemplate" %}
             "{{ attribute.value }}",
-            {%- endif %}
             {%- else %}
-            None,  # Will be auto-generated
+            None,
             {%- endif %}
             {%- elif attrname == "datacontenttype" %}
             content_type,
@@ -849,12 +846,7 @@ class {{ class_name }}:
             {%- endif %}
         {%- endfor %}
         }
-        if 'time' in attributes:
-            normalized_time = _normalize_cloudevents_time(attributes['time'])
-            if normalized_time is None:
-                del attributes['time']
-            else:
-                attributes['time'] = normalized_time
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         
         # Remove None values
         attributes = {k: v for k, v in attributes.items() if v is not None}
@@ -948,7 +940,7 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
         _{{ attrname }}: str,
         {%- endfor %}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
         _{{ placeholder | snake }}: str,
         {%- endfor %}
@@ -960,6 +952,7 @@ class {{ class_name }}:
         {%- for argname in protocol_option_arg_names.items %}
         _{{ argname }}: str,
         {%- endfor %}
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
         Send multiple `{{ messageid }}` messages
@@ -970,7 +963,7 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
             _{{ attrname }} (str): CloudEvents required attribute '{{ attrname }}'
         {%- endfor %}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }} (str): Value for placeholder {{ placeholder }} in attribute {{ attrname }}
         {%- endfor %}
@@ -978,6 +971,7 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
             _{{ attrname }} ({% if not attribute.required %}typing.Optional[str]{% else %}str{% endif %}): CloudEvent {{ attrname }} attribute
         {%- endfor %}
+            _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         {%- endif %}
         {%- for argname in protocol_option_arg_names.items %}
             _{{ argname }} (str): Value for AMQP protocol option placeholder {{ argname }}
@@ -991,7 +985,7 @@ class {{ class_name }}:
                 {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
                 _{{ attrname }}=_{{ attrname }},
                 {%- endfor %}
-                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
                 {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
                 _{{ placeholder | snake }}=_{{ placeholder | snake }},
                 {%- endfor %}
@@ -999,6 +993,7 @@ class {{ class_name }}:
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
                 _{{ attrname }}=_{{ attrname }},
                 {%- endfor %}
+                _time=_time,
                 {%- endif %}
                 {%- for argname in protocol_option_arg_names.items %}
                 _{{ argname }}=_{{ argname }},

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -766,6 +766,15 @@ class {{ class_name }}:
     {%- endfor %}
     {%- endfor %}
     {%- endfor %}
+    {%- set time_arg_names = namespace(items=[]) %}
+    {%- if isCloudEvent and 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value %}
+    {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+    {%- set argname = placeholder | snake %}
+    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items and argname not in time_arg_names.items %}
+    {%- set _ = time_arg_names.items.append(argname) %}
+    {%- endif %}
+    {%- endfor %}
+    {%- endif %}
     
     def send_{{ messagename | snake }}(self,
         data: {{ type_name }},
@@ -784,6 +793,9 @@ class {{ class_name }}:
         {%- endif %}
         {%- for argname in protocol_option_arg_names.items %}
         _{{ argname }}: str,
+        {%- endfor %}
+        {%- for argname in time_arg_names.items %}
+        _{{ argname }}: typing.Optional[str] = None,
         {%- endfor %}
         _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
@@ -810,6 +822,9 @@ class {{ class_name }}:
         {%- for argname in protocol_option_arg_names.items %}
             _{{ argname }} (str): Value for AMQP protocol option placeholder {{ argname }}
         {%- endfor %}
+        {%- for argname in time_arg_names.items %}
+            _{{ argname }} (typing.Optional[str]): Legacy compatibility placeholder for CloudEvents time.
+        {%- endfor %}
             _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             data ({{ type_name }}): The message data object
             content_type (str): The content type of the message data (default: 'application/json')
@@ -825,11 +840,7 @@ class {{ class_name }}:
             {%- if attrname == "id" %}
             str(uuid.uuid4()),
             {%- elif attrname == "time" %}
-            {%- if attribute.value and attribute.type != "uritemplate" %}
-            "{{ attribute.value }}",
-            {%- else %}
-            None,
-            {%- endif %}
+            {{ cloudEvents.RenderLegacyTimeFallback(attribute, "_") }},
             {%- elif attrname == "datacontenttype" %}
             content_type,
             {%- elif attrname == "dataschema" %}
@@ -952,6 +963,9 @@ class {{ class_name }}:
         {%- for argname in protocol_option_arg_names.items %}
         _{{ argname }}: str,
         {%- endfor %}
+        {%- for argname in time_arg_names.items %}
+        _{{ argname }}: typing.Optional[str] = None,
+        {%- endfor %}
         _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = 'application/json') -> None:
         """
@@ -970,6 +984,9 @@ class {{ class_name }}:
         {%- endfor %}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
             _{{ attrname }} ({% if not attribute.required %}typing.Optional[str]{% else %}str{% endif %}): CloudEvent {{ attrname }} attribute
+        {%- endfor %}
+        {%- for argname in time_arg_names.items %}
+            _{{ argname }} (typing.Optional[str]): Legacy compatibility placeholder for CloudEvents time.
         {%- endfor %}
             _time (typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         {%- endif %}
@@ -992,6 +1009,9 @@ class {{ class_name }}:
                 {%- endfor %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
                 _{{ attrname }}=_{{ attrname }},
+                {%- endfor %}
+                {%- for argname in time_arg_names.items %}
+                _{{ argname }}=_{{ argname }},
                 {%- endfor %}
                 _time=_time,
                 {%- endif %}

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -6,6 +6,7 @@
 Tests for {{ main_project_name }}
 """
 import base64
+import datetime
 import json
 import os
 import sys

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -348,7 +348,7 @@ class Test{{ class_name }}:
             assert producer.content_mode == 'structured'
             {%- set extra_args = namespace(items=[]) %}
             {%- if isCloudEvent %}
-                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
                     {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
                         {%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}
                     {%- endfor %}
@@ -374,6 +374,7 @@ class Test{{ class_name }}:
                 {%- for arg in extra_args.items %}
                     {{ arg }}="value",
                 {%- endfor %}
+                    _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
                     content_type="application/json"
                 )
 

--- a/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -59,9 +59,21 @@ class {{ class_name }}:
     {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
+    {%- set time_placeholder_params = [] -%}
+    {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
+        {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+            {%- set placeholder_name = placeholder | snake -%}
+            {%- if placeholder_name not in time_placeholder_params -%}
+                {%- set _ = time_placeholder_params.append(placeholder_name) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
     data: {{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}, content_type: str = "application/json"
     {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
         , _{{ attrname }}: typing.Optional[str] = None
+    {%- endfor -%}
+    {%- for placeholder_name in time_placeholder_params -%}
+        , _{{ placeholder_name }}: typing.Optional[str] = None
     {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None ) -> None:
         """
         Sends the '{{ messageid }}' event to the EventHub
@@ -83,6 +95,9 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+        {%- for placeholder_name in time_placeholder_params %}
+            _{{ placeholder_name }}(typing.Optional[str]): Legacy compatibility placeholder for CloudEvents time.
+        {%- endfor %}
             _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         """
 
@@ -93,11 +108,7 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
             {%- if attrname == "time" -%}
-            {%- if attribute.value and attribute.type != "uritemplate" -%}
-            "{{ attribute.value }}"
-            {%- else -%}
-            None
-            {%- endif -%}
+            {{ cloudEvents.RenderLegacyTimeFallback(attribute, "_") }}
             {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}

--- a/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -1,11 +1,16 @@
 {%- import "util.include.jinja" as util -%}
+{%- import "cloudevents.jinja.include" as cloudEvents -%}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import sys
+import re
 import typing
+from datetime import datetime, timezone
 from azure.eventhub import EventHubProducerClient, EventData
 from cloudevents.conversion import to_binary, to_structured
 from cloudevents.http import CloudEvent
+
+{{ cloudEvents.DeclareRfc3339TimeNormalizer() }}
 
 
 {%- set messagegroups = root.messagegroups %}
@@ -48,16 +53,16 @@ class {{ class_name }}:
     {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata -%}
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" -%}
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
     data: {{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}, content_type: str = "application/json"
-    {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
         , _{{ attrname }}: typing.Optional[str] = None
-    {%- endfor -%} ) -> None:
+    {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None ) -> None:
         """
         Sends the '{{ messageid }}' event to the EventHub
 
@@ -65,19 +70,20 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
             _{{ attrname }}(str) : CloudEvents required attribute '{{ attrname }}'
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(str) : {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }}(str):  Value for placeholder {{ placeholder }} in attribute {{ attrname }}
             {%- endfor -%}
         {%- endfor %}
             data: ({{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
-        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         """
 
         attributes = {
@@ -86,7 +92,13 @@ class {{ class_name }}:
         {%- endfor -%}
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
-            {%- if attribute.value -%}
+            {%- if attrname == "time" -%}
+            {%- if attribute.value and attribute.type != "uritemplate" -%}
+            "{{ attribute.value }}"
+            {%- else -%}
+            None
+            {%- endif -%}
+            {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}
                 {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
@@ -106,6 +118,7 @@ class {{ class_name }}:
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # coerce to bytes so the cloudevents-sdk emits a binary AMQP data

--- a/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
@@ -183,14 +183,15 @@ async def {{ test_function_name | dotunderscore }}(event_hub_emulator):
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
         await producer_instance.send_{{ messageid | dotunderscore | snake }}(
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
-                _{{ attrname }} = {{ "f'test_{i}'" if not attrname == 'time' else 'datetime.datetime.now().isoformat()' }},
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != 'time' -%}
+                _{{ attrname }} = f'test_{{ attrname }}_{i}',
             {%- endfor -%}
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' -%}
                 {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
             {%- endfor -%}
+            _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data = event_data
-            {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+            {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != 'time' -%}
                 , _{{ attrname }} = ''
             {%- endfor -%}
         )

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -96,7 +96,7 @@ class {{ class_name }}:
     {%- set kafka_key_value = msg_key_holder[0] if msg_key_holder else None %}
     {#- Collect already-declared envelope URI template placeholders -#}
     {%- set declared_params = [] %}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
     {%- for ph in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
     {%- if (ph | snake) not in declared_params %}{%- set _ = declared_params.append(ph | snake) %}{%- endif %}
     {%- endfor -%}
@@ -106,10 +106,10 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata -%}
         _{{ attrname }}: str, {{ '' }}
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" -%}
         _{{ attrname }}: str, {{ '' }}
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
         {%- endfor -%}
         {%- if kafka_key_value -%}
@@ -118,9 +118,9 @@ class {{ class_name }}:
             {%- endfor -%}
         {%- endif -%}
         data: {{ data_type | strip_namespace -}}, content_type: str = "application/json"
-        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
             , _{{ attrname }}: typing.Optional[str] = None
-        {%- endfor -%}, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]=None) -> None:
+        {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]=None) -> None:
         """
         Sends the '{{ messageid }}' event to the Kafka topic
 
@@ -128,10 +128,10 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
             _{{ attrname }}(str) : CloudEvents required attribute '{{ attrname }}'
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(str) : {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }}(str):  Value for placeholder {{ placeholder }} in attribute {{ attrname }}
             {%- endfor -%}
@@ -145,9 +145,10 @@ class {{ class_name }}:
         {%- endif %}
             data: ({{ data_type | strip_namespace -}}): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
-        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
         {%- if kafka_key_value %}
@@ -170,7 +171,13 @@ class {{ class_name }}:
         {%- endfor -%}
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
-            {%- if attribute.value -%}
+            {%- if attrname == "time" -%}
+            {%- if attribute.value and attribute.type != "uritemplate" -%}
+            "{{ attribute.value }}"
+            {%- else -%}
+            None
+            {%- endif -%}
+            {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}
                 {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
@@ -190,12 +197,7 @@ class {{ class_name }}:
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
-        if 'time' in attributes:
-            normalized_time = _normalize_cloudevents_time(attributes['time'])
-            if normalized_time is None:
-                del attributes['time']
-            else:
-                attributes['time'] = normalized_time
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         event = CloudEvent.create(attributes, data)
         if self.content_mode == "structured":
             message = to_structured(event, data_marshaller=lambda x: {% if data_type != "object"%}json.loads(x.to_json()){%else%}json.dumps(x){%endif%}, key_mapper=lambda x: self.__key_mapper(x, data, key_mapper, kafka_key))

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -101,6 +101,21 @@ class {{ class_name }}:
     {%- if (ph | snake) not in declared_params %}{%- set _ = declared_params.append(ph | snake) %}{%- endif %}
     {%- endfor -%}
     {%- endfor %}
+    {%- set kafka_key_param_names = [] %}
+    {%- if kafka_key_value -%}
+        {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+            {%- if (placeholder | snake) not in kafka_key_param_names %}{%- set _ = kafka_key_param_names.append(placeholder | snake) %}{%- endif -%}
+        {%- endfor -%}
+    {%- endif %}
+    {%- set time_placeholder_params = [] %}
+    {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
+        {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+            {%- set placeholder_name = placeholder | snake -%}
+            {%- if placeholder_name not in declared_params and placeholder_name not in kafka_key_param_names and placeholder_name not in time_placeholder_params -%}
+                {%- set _ = time_placeholder_params.append(placeholder_name) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif %}
 
     def send_{{message_snake}}(self,
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata -%}
@@ -120,6 +135,9 @@ class {{ class_name }}:
         data: {{ data_type | strip_namespace -}}, content_type: str = "application/json"
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
             , _{{ attrname }}: typing.Optional[str] = None
+        {%- endfor -%}
+        {%- for placeholder_name in time_placeholder_params -%}
+            , _{{ placeholder_name }}: typing.Optional[str] = None
         {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None, flush_producer=True, key_mapper: typing.Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]=None) -> None:
         """
         Sends the '{{ messageid }}' event to the Kafka topic
@@ -148,6 +166,9 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+        {%- for placeholder_name in time_placeholder_params %}
+            _{{ placeholder_name }}(typing.Optional[str]): Legacy compatibility placeholder for CloudEvents time.
+        {%- endfor %}
             _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
             flush_producer(bool): Whether to flush the producer after sending the event (default: True)
             key_mapper(Callable[[CloudEvent, {{ data_type | strip_namespace -}}], str]): A function to map the CloudEvent contents to a Kafka key (default: None).
@@ -172,11 +193,7 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
             {%- if attrname == "time" -%}
-            {%- if attribute.value and attribute.type != "uritemplate" -%}
-            "{{ attribute.value }}"
-            {%- else -%}
-            None
-            {%- endif -%}
+            {{ cloudEvents.RenderLegacyTimeFallback(attribute, "_") }}
             {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}

--- a/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
@@ -177,10 +177,10 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
         producer_instance.send_{{ messageid | dotunderscore | snake }}(
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
-                _{{ attrname }} = {{ "f'test_{i}'" if not attrname == 'time' else 'datetime.datetime.now().isoformat()' }},
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != 'time' -%}
+                _{{ attrname }} = f'test_{i}',
             {%- endfor -%}
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' -%}
                 {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
             {%- endfor -%}
             {%- if kafka_key_value -%}
@@ -188,8 +188,9 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
                     {%- if (placeholder | snake) not in declared_params %}_{{ placeholder | snake }} = f'test_{i}', {% endif -%}
                 {%- endfor -%}
             {%- endif -%}
+            _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data = event_data
-            {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+            {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != 'time' -%}
                 , _{{ attrname }} = ''
             {%- endfor -%}
         )

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -432,6 +432,14 @@ class {{ class_name }}(_ClientBase):
             {%- endfor %}
         {%- endif %}
     {%- endif %}
+    {%- set time_uri_template_vars = [] %}
+    {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].value and message.envelopemetadata['time'].type == "uritemplate" -%}
+        {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+            {%- if placeholder not in uri_template_vars and placeholder not in time_uri_template_vars -%}
+                {%- set _ = time_uri_template_vars.append(placeholder) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif %}
     {#- Per-message QoS and retain defaults pulled from protocoloptions.
         Supports both the direct-scalar form (protocoloptions.qos = 1) and the
         spec's properties-map form (protocoloptions.properties.qos.value = 1). -#}
@@ -468,6 +476,9 @@ class {{ class_name }}(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        {%- for var in time_uri_template_vars %}
+        {{ var | snake }}: Optional[str] = None,
+        {%- endfor %}
         _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
@@ -487,6 +498,9 @@ class {{ class_name }}(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default ({{ default_qos }}).
             retain: Optional MQTT retain flag override. If not provided, uses the message default ({{ default_retain }}).
+        {%- for var in time_uri_template_vars %}
+            {{ var | snake }}: Legacy compatibility placeholder for CloudEvents time.
+        {%- endfor %}
             _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
@@ -503,11 +517,7 @@ class {{ class_name }}(_ClientBase):
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
             {%- if attrname == "time" -%}
-            {%- if attribute.value and attribute.type != "uritemplate" -%}
-            "{{ attribute.value }}"
-            {%- else -%}
-            None
-            {%- endif -%}
+            {{ cloudEvents.RenderLegacyTimeFallback(attribute, "") }}
             {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -400,7 +400,7 @@ class {{ class_name }}(_ClientBase):
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) %}
     {%- set uri_template_vars = [] %}
     {%- for attrname, attribute in message.envelopemetadata.items() %}
-        {%- if attribute.value and attribute.type == "uritemplate" %}
+        {%- if attribute.value and attribute.type == "uritemplate" and attrname != "time" %}
             {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             {%- if phs %}
                 {%- for placeholder in phs %}
@@ -457,7 +457,7 @@ class {{ class_name }}(_ClientBase):
     {%- endif %}
     async def publish_{{messagename.split('.')[-1]}}(self,
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.value -%}
-        {%- if attribute.type != "uritemplate" -%}
+        {%- if attribute.type != "uritemplate" and attrname != "time" -%}
         _{{ attrname | snake }}: str,
         {%- endif -%}
         {%- endfor %}
@@ -468,13 +468,14 @@ class {{ class_name }}(_ClientBase):
         topic: Optional[str] = None,
         qos: Optional[int] = None,
         retain: Optional[bool] = None,
+        _time: typing.Optional[typing.Union[str, datetime]] = None,
         content_type: str = "application/json") -> None:
         """
         Publish the '{{ messageid }}' event to an MQTT topic.
 
         Args:
         {% for attrname, attribute in message.envelopemetadata.items() if not attribute.value -%}
-        {%- if attribute.type != "uritemplate" -%}
+        {%- if attribute.type != "uritemplate" and attrname != "time" -%}
             _{{ attrname | snake }}: CloudEvents attribute '{{attrname}}'
         {%- endif -%}
         {%- endfor %}
@@ -486,6 +487,7 @@ class {{ class_name }}(_ClientBase):
                 with URI template placeholders substituted from the keyword arguments.
             qos: Optional MQTT QoS override. If not provided, uses the message default ({{ default_qos }}).
             retain: Optional MQTT retain flag override. If not provided, uses the message default ({{ default_retain }}).
+            _time: Optional CloudEvents time override. Defaults to current UTC when no catalog time is used.
             content_type: The content type for the event data.
         """
         target_topic = topic if topic is not None else "{{ get_default_topic(message, messageid) }}"
@@ -500,7 +502,13 @@ class {{ class_name }}(_ClientBase):
         attributes = {
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
-            {%- if attribute.value -%}
+            {%- if attrname == "time" -%}
+            {%- if attribute.value and attribute.type != "uritemplate" -%}
+            "{{ attribute.value }}"
+            {%- else -%}
+            None
+            {%- endif -%}
+            {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}
                 {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
@@ -520,12 +528,7 @@ class {{ class_name }}(_ClientBase):
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
-        if 'time' in attributes:
-            normalized_time = _normalize_cloudevents_time(attributes['time'])
-            if normalized_time is None:
-                del attributes['time']
-            else:
-                attributes['time'] = normalized_time
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON);
         # paho-mqtt will UTF-8 encode str payloads, but cloudevents-sdk's

--- a/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
+++ b/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
@@ -145,25 +145,18 @@ async def test_{{groupName}}_{{messagename.split('.')[-1]}}_py(mosquitto_broker)
         await publisher_client.publish_{{messagename.split('.')[-1]}}(
             topic=test_topic,
             {%- for attrname, attribute in message.envelopemetadata.items() %}
-            {%- if attribute.type == "uritemplate" and attribute.value %}
+            {%- if attribute.type == "uritemplate" and attribute.value and attrname != "time" %}
             {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             {%- if phs %}
             {%- for placeholder in phs %}
-            {%- if attrname == "time" %}
-            {{ placeholder | snake }}=datetime.datetime.now().isoformat(),
-            {%- else %}
             {{ placeholder | snake }}=f"test_{{placeholder}}_{i}",
-            {%- endif %}
             {%- endfor %}
             {%- endif %}
-            {%- elif not attribute.value %}
-            {%- if attrname == "time" %}
-            _{{ attrname | snake }}=datetime.datetime.now().isoformat(),
-            {%- else %}
+            {%- elif not attribute.value and attrname != "time" %}
             _{{ attrname | snake }}=f"test_{{attrname}}_{i}",
             {%- endif %}
-            {%- endif %}
             {%- endfor %}
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data,
             content_type="application/json"
         )

--- a/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -1,12 +1,17 @@
 {%- import "util.include.jinja" as util -%}
+{%- import "cloudevents.jinja.include" as cloudEvents -%}
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import json
+import re
 import typing
+from datetime import datetime, timezone
 from azure.servicebus.aio import ServiceBusClient
 from azure.servicebus import ServiceBusMessage
 from cloudevents.conversion import to_binary, to_structured
 from cloudevents.http import CloudEvent
+
+{{ cloudEvents.DeclareRfc3339TimeNormalizer() }}
 
 
 {%- set messagegroups = root.messagegroups %}
@@ -67,16 +72,16 @@ class {{ class_name }}:
     {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata -%}
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" -%}
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
-    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
     data: {{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}, content_type: str = "application/json"
-    {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined -%}
+    {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
         , _{{ attrname }}: typing.Optional[str] = None
-    {%- endfor -%} ) -> None:
+    {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None ) -> None:
         """
         Sends the '{{ messageid }}' event to the EventHub
 
@@ -84,19 +89,20 @@ class {{ class_name }}:
         {%- for attrname in ['source', 'type'] if attrname not in message.envelopemetadata %}
             _{{ attrname }}(str) : CloudEvents required attribute '{{ attrname }}'
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(str) : {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor -%}
-        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }}(str):  Value for placeholder {{ placeholder }} in attribute {{ attrname }}
             {%- endfor -%}
         {%- endfor %}
             data: ({{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}): The event data to be sent
             content_type (str): The content type that the event data shall be sent with
-        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined %}
+        {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+            _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         """
 
         attributes = {
@@ -105,7 +111,13 @@ class {{ class_name }}:
         {%- endfor -%}
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
-            {%- if attribute.value -%}
+            {%- if attrname == "time" -%}
+            {%- if attribute.value and attribute.type != "uritemplate" -%}
+            "{{ attribute.value }}"
+            {%- else -%}
+            None
+            {%- endif -%}
+            {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}
                 {%- set phs = attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
@@ -125,6 +137,7 @@ class {{ class_name }}:
         {%- endfor %}
         }
         attributes["datacontenttype"] = content_type
+        attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))
         byte_data = data.to_byte_array(content_type) if data is not None else b''
         # to_byte_array returns str for text content types (e.g. JSON); coerce
         # to bytes so the wire body is the exact serialized representation

--- a/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -78,9 +78,21 @@ class {{ class_name }}:
     {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
         {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
+    {%- set time_placeholder_params = [] -%}
+    {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
+        {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
+            {%- set placeholder_name = placeholder | snake -%}
+            {%- if placeholder_name not in time_placeholder_params -%}
+                {%- set _ = time_placeholder_params.append(placeholder_name) -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
     data: {{ util.DeclareDataType( project_name, root, message ) | strip_namespace -}}, content_type: str = "application/json"
     {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" -%}
         , _{{ attrname }}: typing.Optional[str] = None
+    {%- endfor -%}
+    {%- for placeholder_name in time_placeholder_params -%}
+        , _{{ placeholder_name }}: typing.Optional[str] = None
     {%- endfor -%}, _time: typing.Optional[typing.Union[str, datetime]] = None ) -> None:
         """
         Sends the '{{ messageid }}' event to the EventHub
@@ -102,6 +114,9 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() if not attribute.required and attribute.value is not defined and attrname != "time" %}
             _{{ attrname }}(typing.Optional[str]): {{ attribute.description if attribute.description else "CloudEvents attribute '"+attrname+"'" }}
         {%- endfor %}
+        {%- for placeholder_name in time_placeholder_params %}
+            _{{ placeholder_name }}(typing.Optional[str]): Legacy compatibility placeholder for CloudEvents time.
+        {%- endfor %}
             _time(typing.Optional[typing.Union[str, datetime]]): CloudEvents time override. Defaults to current UTC when no catalog time is used.
         """
 
@@ -112,11 +127,7 @@ class {{ class_name }}:
         {%- for attrname, attribute in message.envelopemetadata.items() %}
              "{{ attrname }}":
             {%- if attrname == "time" -%}
-            {%- if attribute.value and attribute.type != "uritemplate" -%}
-            "{{ attribute.value }}"
-            {%- else -%}
-            None
-            {%- endif -%}
+            {{ cloudEvents.RenderLegacyTimeFallback(attribute, "_") }}
             {%- elif attribute.value -%}
             "{{ attribute.value }}"
             {%- if attribute.type == "uritemplate" -%}

--- a/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
@@ -175,14 +175,15 @@ async def {{ test_function_name | dotunderscore }}(service_bus_emulator):
     # Send 5 messages to test message settlement and ordering
     for i in range(5):
         await producer.send_{{ message_snake.split('.')[-1] }}(
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined %}
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined and attrname != 'time' %}
             _{{ attrname }}=f"test_{{ attrname }}_{i}",
             {%- endfor %}
-            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" %}
+            {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' %}
             {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
             _{{ placeholder | snake }}=f"test_{{ placeholder }}_{i}",
             {%- endfor %}
             {%- endfor %}
+            _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data=test_data
         )
     

--- a/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
@@ -2,6 +2,7 @@
 # pylint: disable=missing-function-docstring, wrong-import-position, import-error, no-name-in-module, import-outside-toplevel, no-member, redefined-outer-name, unused-argument, unused-variable, invalid-name, redefined-outer-name, missing-class-docstring
 
 import asyncio
+import datetime
 import logging
 import os
 import sys


### PR DESCRIPTION
## Summary
- add a dedicated _time override across the Python sender templates
- keep legacy full-value time uritemplate placeholders accepted as optional fallback parameters
- default CloudEvents time to current UTC when neither override nor legacy fallback is supplied

## Testing
- pytest test\\py\\test_python.py::test_kafkaproducer_time_uritemplate_is_normalized_before_cloudevent_creation test\\py\\test_python.py::test_amqpproducer_time_uritemplate_sets_ce_and_creation_time test\\py\\test_python.py::test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation test\\py\\test_python.py::test_generated_py_cloudevents_time_helpers_validate_and_resolve test\\py\\test_python.py::test_ehproducer_exposes_time_override_argument test\\py\\test_python.py::test_sbproducer_exposes_time_override_argument