### PR TITLE
Fix Python AMQP pre-settled sender drain

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -403,6 +403,7 @@ def test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender():
     assert "sender_options = AtMostOnce() if self.username and self.password else None" in src
     assert "self._sender = self._connection.create_sender(self.address, options=sender_options)" in src
     assert "self._sender.send(amqp_msg, timeout=timeout)" in src
+    assert "self._sender.link.queued == 0" in src
     assert "self._connection.conn.transport.pending() == 0" in src
     assert 'msg=f"Flushing sender {self._sender.link.name} transport"' in src
     assert "self._send_via_blocking_sender(amqp_msg)" in src

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -641,9 +641,11 @@ class {{ class_name }}:
         self._sender.send(amqp_msg, timeout=timeout)
         if self._blocking_sender_is_presettled:
             # BlockingSender.send() returns immediately for pre-settled
-            # deliveries, so wait until Proton has flushed all pending bytes.
+            # deliveries, so wait until Proton has drained the link queue
+            # and flushed all pending bytes.
             self._connection.wait(
                 lambda: (
+                    self._sender.link.queued == 0 and
                     self._connection.conn.transport is not None and
                     self._connection.conn.transport.pending() == 0
                 ),

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -19,7 +19,7 @@ from urllib.parse import quote_plus
 import pytest
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
-from proton import symbol
+from proton import Message, symbol
 from proton.utils import BlockingConnection
 
 {%- set amqp_message_property_attributes = {
@@ -300,6 +300,45 @@ class Test{{ class_name }}:
         assert producer.port == artemis_container["port"]
         assert producer.username == artemis_container["username"]
         producer.close()
+
+    def test_presettled_send_waits_for_queued_delivery_to_drain(self):
+        """Pre-settled sends must not return before queued deliveries are written."""
+
+        class FakeTransport:
+            def pending(self):
+                return 0
+
+        class FakeSender:
+            def __init__(self):
+                self.link = type("Link", (), {"queued": 1, "name": "fake-link"})()
+                self.calls = []
+
+            def send(self, amqp_msg, timeout=30.0):
+                self.calls.append((amqp_msg, timeout))
+
+        fake_sender = FakeSender()
+
+        class FakeConnection:
+            def __init__(self):
+                self.conn = type("Conn", (), {"transport": FakeTransport()})()
+                self.wait_calls = 0
+
+            def wait(self, predicate, msg=None, timeout=None):
+                self.wait_calls += 1
+                assert not predicate()
+                fake_sender.link.queued = 0
+                assert predicate()
+
+        fake_connection = FakeConnection()
+        producer = object.__new__({{ class_name }})
+        producer._sender = fake_sender
+        producer._connection = fake_connection
+        producer._blocking_sender_is_presettled = True
+
+        producer._send_via_blocking_sender(Message(body=b"payload", inferred=True), timeout=7.5)
+
+        assert len(fake_sender.calls) == 1
+        assert fake_connection.wait_calls == 1
     
     {%- for messageid, message in messagegroup.messages.items() %}
     {%- set messagename = messageid | pascal | strip_namespace %}
@@ -432,6 +471,92 @@ class Test{{ class_name }}:
                 {%- endif %}
         finally:
             producer.close()
+
+    def test_send_{{ messagename | snake }}_single_fresh_connection(self, artemis_container):
+        """Send exactly one {{ messagename }} message on a fresh producer connection."""
+        {%- if type_name != "object" %}
+        payload = Test_{{ type_name | pascal | strip_namespace }}.create_instance()
+        {%- else %}
+        payload = {"message": "{{ messageid }}-payload"}
+        {%- endif %}
+
+        producer = {{ class_name }}(
+            host=artemis_container["host"],
+            address=artemis_container["address"],
+            port=artemis_container["port"],
+            username=artemis_container["username"],
+            password=artemis_container["password"],
+            content_mode='binary'
+        )
+
+        try:
+            {%- set extra_args = namespace(items=[]) %}
+            {%- if isCloudEvent %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
+                    {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+                        {%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}
+                    {%- endfor %}
+                {%- endfor %}
+                {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
+                    {%- set _ = extra_args.items.append('_' + attrname) %}
+                {%- endfor %}
+            {%- endif %}
+            {%- for propmap in [message_properties, message_application_properties, message_annotations] if propmap %}
+                {%- for propname, prop in propmap.items() if prop.value is defined %}
+                    {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+                        {%- set arg = '_' + (placeholder | snake) %}
+                        {%- if arg not in extra_args.items %}
+                            {%- set _ = extra_args.items.append(arg) %}
+                        {%- endif %}
+                    {%- endfor %}
+                {%- endfor %}
+            {%- endfor %}
+            producer.send_{{ messagename | snake }}(
+                data=payload,
+            {%- for arg in extra_args.items %}
+                {{ arg }}="value",
+            {%- endfor %}
+                _time=datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                content_type="application/json"
+            )
+        finally:
+            producer.close()
+
+        received = _receive_single_message(artemis_container)
+        properties = received.properties or {}
+        annotations = received.annotations or {}
+
+        {%- if isCloudEvent %}
+        assert properties.get('cloudEvents:type') == '{{ messageid }}'
+        {%- else %}
+        {%- if ('subject' not in message_properties) and ('subject' not in message_application_properties) %}
+        assert properties.get('subject') == '{{ messageid }}'
+        {%- endif %}
+        {%- endif %}
+        assert received.body is not None
+
+        {%- if message_properties %}
+        {%- for propname, prop in message_properties.items() if prop.value is defined %}
+        {%- set property_key = propname | lower %}
+        {%- if property_key in amqp_message_property_attributes %}
+        assert received.{{ amqp_message_property_attributes[property_key] }} == {{ protocol_option_expected_value(prop) }}
+        {%- endif %}
+        {%- endfor %}
+        {%- endif %}
+        {%- if message_application_properties %}
+        {%- for propname, prop in message_application_properties.items() if prop.value is defined %}
+        assert properties.get('{{ propname }}') == {{ protocol_option_expected_value(prop) }}
+        {%- endfor %}
+        {%- endif %}
+        {%- if message_annotations %}
+        {%- for annotation_name, annotation in message_annotations.items() if annotation.value is defined %}
+        {%- if annotation_name == "x-opt-partition-key" %}
+        assert annotations.get(symbol('{{ annotation_name }}')) == str({{ protocol_option_expected_value(annotation) }})[:128]
+        {%- else %}
+        assert annotations.get(symbol('{{ annotation_name }}')) == {{ protocol_option_expected_value(annotation) }}
+        {%- endif %}
+        {%- endfor %}
+        {%- endif %}
     
     {%- endfor %}
 


### PR DESCRIPTION
Root cause: pre-settled sends only waited for transport.pending()==0 even when deliveries could still be queued on the Proton link. Validation: python -m pytest test\\py\\test_python.py -k test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender -q; python -m pytest test\\py\\test_python.py -k test_amqpproducer_lightbulb_py -q -x; python -m pytest test\\py\\test_python.py -k "test_amqpproducer_password_mode_uses_artemis_safe_blocking_sender or test_amqpproducer_lightbulb_py" -q.