### PR TITLE
Fix Python Kafka exports for mixed schemagroups

### DIFF
--- a/test/codegen/test_codegen.py
+++ b/test/codegen/test_codegen.py
@@ -1,5 +1,6 @@
 import platform
 import re
+import json
 import xrcg
 import random
 import string
@@ -179,3 +180,161 @@ def test_codegen_py_kafkaproducer_basemessageuri():
                 '--projectname', 'test_kafkaproducer_basemessageuri']
     assert xrcg.cli() == 0
 
+
+def test_codegen_py_kafkaproducer_keeps_jstruct_exports_with_unused_avro_schemas():
+    """Regression test for issue #371.
+
+    Full-document generation must not treat inline schema bodies under
+    ``schemagroups`` as additional top-level schema references. Doing so makes
+    the Python data package process alternate schema encodings twice and can
+    overwrite ``__init__.py`` exports for JsonStructure-only types.
+    """
+    work_dir = tempfile.mkdtemp()
+    try:
+        definitions_path = os.path.join(work_dir, 'issue-371.xreg.json')
+        output_dir = os.path.join(work_dir, 'out')
+
+        document = {
+            "specversion": "1.0-rc2",
+            "endpoints": {
+                "Test.Reference.Kafka": {
+                    "usage": ["producer"],
+                    "protocol": "KAFKA",
+                    "envelope": "CloudEvents/1.0",
+                    "envelopeoptions": {
+                        "mode": "structured",
+                        "format": "application/cloudevents+json"
+                    },
+                    "protocoloptions": {
+                        "options": {
+                            "topic": "issue-371",
+                            "key": "{entity_id}"
+                        }
+                    },
+                    "messagegroups": [
+                        "#/messagegroups/Test.Reference"
+                    ]
+                }
+            },
+            "messagegroups": {
+                "Test.Reference": {
+                    "messages": {
+                        "Test.Reference.Info": {
+                            "name": "Info",
+                            "envelope": "CloudEvents/1.0",
+                            "description": "Referenced JsonStructure message.",
+                            "envelopemetadata": {
+                                "type": {"value": "Test.Reference.Info"},
+                                "source": {
+                                    "value": "https://example.test/issue-371",
+                                    "type": "uritemplate"
+                                },
+                                "subject": {
+                                    "value": "{entity_id}",
+                                    "type": "uritemplate"
+                                }
+                            },
+                            "dataschemaformat": "JsonStructure/draft-02",
+                            "dataschemauri": "#/schemagroups/Test.jstruct/schemas/Test.Reference.Info"
+                        }
+                    }
+                }
+            },
+            "schemagroups": {
+                "Test.jstruct": {
+                    "schemas": {
+                        "Test.Reference.Info": {
+                            "defaultversionid": "v1",
+                            "versions": {
+                                "v1": {
+                                    "schemaid": "Test.Reference.Info",
+                                    "format": "JsonStructure/draft-02",
+                                    "schema": {
+                                        "$schema": "https://json-structure.org/meta/core/v0/#",
+                                        "name": "Info",
+                                        "type": "object",
+                                        "description": "JsonStructure-only reference data type.",
+                                        "properties": {
+                                            "entity_id": {
+                                                "type": "string",
+                                                "description": "Stable identifier."
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "description": "Display name."
+                                            }
+                                        },
+                                        "required": ["entity_id", "name"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "Test.avro": {
+                    "schemas": {
+                        "Test.Reference.Unused": {
+                            "defaultversionid": "v1",
+                            "versions": {
+                                "v1": {
+                                    "schemaid": "Test.Reference.Unused",
+                                    "format": "Avro/1.11.3",
+                                    "schema": {
+                                        "type": "record",
+                                        "name": "Unused",
+                                        "namespace": "Test.Reference",
+                                        "doc": "Unreferenced alternate schema format.",
+                                        "fields": [
+                                            {
+                                                "name": "entity_id",
+                                                "type": "string",
+                                                "doc": "Stable identifier."
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        with open(definitions_path, 'w', encoding='utf-8') as handle:
+            json.dump(document, handle, indent=2)
+
+        sys.argv = [
+            'xrcg', 'generate',
+            '--style', 'kafkaproducer',
+            '--language', 'py',
+            '--definitions', definitions_path,
+            '--output', output_dir,
+            '--projectname', 'test_issue_371'
+        ]
+        assert xrcg.cli() == 0
+
+        init_path = os.path.join(
+            output_dir,
+            'test_issue_371_data',
+            'src',
+            'test_issue_371_data',
+            '__init__.py'
+        )
+        with open(init_path, 'r', encoding='utf-8') as handle:
+            init_contents = handle.read()
+
+        producer_path = os.path.join(
+            output_dir,
+            'test_issue_371_kafka_producer',
+            'src',
+            'test_issue_371_kafka_producer',
+            'producer.py'
+        )
+        with open(producer_path, 'r', encoding='utf-8') as handle:
+            producer_contents = handle.read()
+
+        assert 'from .info import Info' in init_contents
+        assert '"Info"' in init_contents
+        assert 'from test_issue_371_data import Info' in producer_contents
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)

--- a/test/codegen/test_codegen.py
+++ b/test/codegen/test_codegen.py
@@ -12,6 +12,8 @@ import time
 import tempfile
 
 import pytest
+from xrcg.generator.generator_context import GeneratorContext
+from xrcg.generator.template_renderer import TemplateRenderer
 
 project_root = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../..'))
@@ -338,3 +340,42 @@ def test_codegen_py_kafkaproducer_keeps_jstruct_exports_with_unused_avro_schemas
         assert 'from test_issue_371_data import Info' in producer_contents
     finally:
         shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def test_extract_schema_info_keeps_names_for_top_level_schemagroup_refs():
+    """Top-level schemagroup refs must retain class and namespace metadata.
+
+    Issue #371 stopped collecting inline ``.../versions/.../schema`` refs under
+    ``schemagroups`` to avoid processing alternate encodings twice. The
+    top-level schema ref path still needs to supply the name/namespace metadata
+    required for JSONSchema-to-Avro conversion in the C#/Java generators.
+    """
+    with open(os.path.join(project_root, 'test/xreg/contoso-erp.xreg.json'), 'r', encoding='utf-8') as handle:
+        document = json.load(handle)
+
+    renderer = TemplateRenderer(
+        GeneratorContext(),
+        'test_project',
+        'cs',
+        'amqpconsumer',
+        os.path.join(tempfile.gettempdir(), 'tmp', 'schema-info-check'),
+        '',
+        {},
+        [],
+        {},
+        False,
+        False
+    )
+    schema_ref = '#/schemagroups/Contoso.ERP.Events/schemas/purchaseOrderData'
+    schema_data = renderer.resolve_schema_reference_in_document(schema_ref, document)
+    assert schema_data is not None
+
+    schema_info = renderer.extract_schema_info_from_resolved_data(schema_ref, schema_data)
+    assert schema_info is not None
+    assert schema_info['class_name'] == 'Contoso.ERP.Events.purchaseOrderData'
+    assert schema_info['namespace'] == 'Contoso.ERP.Events'
+
+    renderer.convert_json_to_avro_if_needed(schema_info)
+    assert schema_info['format_short'] == 'avro'
+    assert schema_info['content']['name'] == 'PurchaseOrderData'
+    assert schema_info['content']['namespace'] == 'Contoso.ERP.Events'

--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -1007,6 +1007,18 @@ class TemplateRenderer:
     def collect_schema_references_from_document(self, document: JsonNode) -> set[str]:
         """Collect all schema references from the composed document."""
         schema_refs = set()
+
+        def should_collect_inline_schema(current_path: str) -> bool:
+            """Only collect direct inline schema bodies outside schemagroups.
+
+            Schema versions under ``schemagroups/.../versions/.../schema`` are
+            already reachable through ``dataschema*`` references. Collecting the
+            raw inline body again causes the same logical schema set to be
+            processed twice (for example JsonStructure plus Avro variants in the
+            same manifest), which can overwrite generated package exports.
+            """
+            normalized_path = current_path.replace("\\", "/")
+            return "/schemagroups/" not in f"/{normalized_path}"
         
         def scan_for_schemas(obj: JsonNode, path: str = "") -> None:
             if isinstance(obj, dict):
@@ -1019,8 +1031,10 @@ class TemplateRenderer:
                     
                     # Look for inline schemas
                     elif key == "schema" and isinstance(value, (dict, str)):
-                        schema_pointer = f"#{path}/schema"
-                        schema_refs.add(schema_pointer)
+                        if should_collect_inline_schema(current_path):
+                            schema_pointer = f"#{path}/schema"
+                            schema_refs.add(schema_pointer)
+                        continue
                     
                     # Recursively scan nested objects
                     scan_for_schemas(value, current_path)

--- a/xrcg/generator/template_renderer.py
+++ b/xrcg/generator/template_renderer.py
@@ -1212,21 +1212,14 @@ class TemplateRenderer:
             return None
 
         # Extract names
+        schema_group_id = self._extract_namespace_from_ref(schema_ref)
         schema_id = schema_version.get("schemaid") or parent_schema.get("schemaid", "")
-        class_name = schema_id
+        class_name = schema_id or self._extract_class_name_from_ref(schema_ref)
 
-        # Extract group from reference path
-        schema_group_id = ""
-        if schema_ref.startswith("#"):
-            path_parts = schema_ref.split("/")
-            for i, part in enumerate(path_parts):
-                if part == "schemagroups" and i + 1 < len(path_parts):
-                    schema_group_id = path_parts[i + 1]
-                    break
-
-        # Build qualified class name
-        if schema_group_id and class_name and not class_name.startswith(schema_group_id):
+        if schema_group_id and class_name and "." not in class_name:
             class_name = f"{schema_group_id}.{class_name}"
+
+        namespace = JinjaFilters.namespace(class_name) or schema_group_id
 
         format_short = self._get_format_short(schema_format)
 
@@ -1236,6 +1229,7 @@ class TemplateRenderer:
             "format": schema_format,
             "format_short": format_short,
             "class_name": class_name,
+            "namespace": namespace,
             "schema_id": schema_id,
             "schema_group_id": schema_group_id
         }


### PR DESCRIPTION
## Summary
- stop treating inline `schemagroups/.../versions/.../schema` bodies as additional top-level schema references
- avoid double-processing mixed JsonStructure/Avro schema catalogs into the same Python data package
- add a regression test for the missing `Info` export case from issue #371

## Validation
- `python -m pytest test\codegen\test_codegen.py::test_codegen_py_kafkaproducer_basemessageuri test\codegen\test_codegen.py::test_codegen_py_kafkaproducer_keeps_jstruct_exports_with_unused_avro_schemas`
- regenerated the real-time-sources Ticketmaster Kafka producer with this branch and verified `ticketmaster_producer_data.__init__` exports `Info` while `producer.py` still imports it

Fixes #371.