### PR TITLE
Roll up green Dependabot updates

### DIFF
--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache vcpkg
         id: vcpkg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             C:/vcpkg/installed
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all wheel artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: wheel-*
           path: dist
@@ -132,7 +132,7 @@ jobs:
         run: ls -lh dist/
 
       - name: Create / update Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "proton-windows-${{ github.event.inputs.proton_version }}+xrcg${{ github.event.inputs.xrcg_build }}"
           name: "python-qpid-proton ${{ github.event.inputs.proton_version }}+xrcg${{ github.event.inputs.xrcg_build }} (Windows OpenSSL)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Set up .NET SDK
-      uses: actions/setup-dotnet@v5.2.0
+      uses: actions/setup-dotnet@v5.3.0
       with:
         dotnet-version: 10.0.x
     - name: Check dotnet version
@@ -234,4 +234,3 @@ jobs:
     - name: Report disk space after cleanup
       if: always()
       run: df -h
-

--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -5,7 +5,7 @@
     <ItemGroup>
       <PackageReference Include="AMQPNetLite" Version="2.5.2" />
       <PackageReference Include="Apache.Avro" Version="1.12.1" />
-      <PackageReference Include="Azure.Core" Version="1.52.0" />
+      <PackageReference Include="Azure.Core" Version="1.57.0" />
       <PackageReference Include="Azure.Core.Amqp" Version="1.3.1" />
       <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
       <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
@@ -27,16 +27,16 @@
       <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.5" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
       <PackageReference Include="System.Memory.Data" Version="10.0.8" />
       <PackageReference Include="System.Text.Json" Version="10.0.8" />
-      <PackageReference Include="Testcontainers" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
+      <PackageReference Include="Testcontainers" Version="4.12.0" />
+      <PackageReference Include="Testcontainers.ActiveMq" Version="4.12.0" />
+      <PackageReference Include="Testcontainers.Azurite" Version="4.12.0" />
       <PackageReference Include="Testcontainers.Kafka" Version="4.11.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">

--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-      <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+      <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
       <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.8.0" />
@@ -25,7 +25,7 @@
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
       <PackageReference Include="Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents" Version="1.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/xrcg/dependencies/cs/net90/dependencies.csproj
+++ b/xrcg/dependencies/cs/net90/dependencies.csproj
@@ -31,7 +31,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-      <PackageReference Include="System.Memory.Data" Version="10.0.6" />
+      <PackageReference Include="System.Memory.Data" Version="10.0.8" />
       <PackageReference Include="System.Text.Json" Version="10.0.8" />
       <PackageReference Include="Testcontainers" Version="4.11.0" />
       <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.0</version>
+            <version>2.21.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -177,12 +177,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.25.2</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.2</version>
+            <version>2.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>6.0.3</version>
+            <version>6.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/xrcg/dependencies/typescript/node22/package.json
+++ b/xrcg/dependencies/typescript/node22/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@jest/globals": "^30.2.0",
     "@stylistic/eslint-plugin": "^5.6.1",
-    "@testcontainers/kafka": "^11.7.2",
+    "@testcontainers/kafka": "^12.0.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.0.10",
     "@types/uuid": "^11.0.0",
@@ -26,7 +26,7 @@
     "eslint": "^10.1.0",
     "jest": "^30.2.0",
     "nock": "^14.0.10",
-    "testcontainers": "^11.8.1",
+    "testcontainers": "^12.0.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.0",
     "typescript": "^6.0.2"


### PR DESCRIPTION
This batches the currently green Dependabot updates into one manual PR so the repository only needs one fresh CI run.

Supersedes: #301, #302, #303, #304, #305, #307, #308, #333, #377, #380, #381, #382, #383, #384, #390, #393, #394, #396, #397.

Left out on purpose: #376 is still failing and should stay isolated until it is fixed separately.

Local validation:
- python -m pytest test\\java\\test_java.py::test_kafkaproducer_lightbulb_java test\\ts\\test_typescript.py::test_kafkaproducer_lightbulb_ts test\\cs\\test_dotnet.py::test_ehproducer_lightbulb_cs
- Generated C# AMQP check still fails on both this branch and origin/main, so it was treated as a pre-existing baseline issue rather than a regression from this rollup.