### PR TITLE
Fix Python MQTT connect authentication wait

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -340,6 +340,9 @@ def _load_generated_python_module_from_path(module_path, extra_paths=None):
     try:
         for extra_path in reversed(extra_paths or []):
             sys.path.insert(0, extra_path)
+        module_dir = os.path.dirname(module_path)
+        if module_dir:
+            sys.path.insert(0, module_dir)
         spec = importlib.util.spec_from_file_location(
             f"generated_{uuid.uuid4().hex}",
             module_path,
@@ -1286,61 +1289,66 @@ def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("callback_style", ["v1", "v2"])
-async def test_mqttclient_connect_waits_for_successful_authentication(callback_style):
+def test_mqttclient_connect_waits_for_successful_authentication(callback_style):
     """Generated MQTT connect() must not return until on_connect reports success."""
-    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
-    loop = asyncio.get_running_loop()
-    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="success", callback_style=callback_style)
-    generated_client = client_class(fake_client, loop=loop)
-    await generated_client.connect("mqtt.example", keepalive=1)
-    assert fake_client.connect_calls == [("mqtt.example", 1883, 1)]
-    assert fake_client.loop_start_calls == 1
-    assert fake_client.loop_stop_calls == 0
-    assert fake_client.authenticated is True
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="success", callback_style=callback_style)
+        generated_client = client_class(fake_client, loop=loop)
+        await generated_client.connect("mqtt.example", keepalive=1)
+        assert fake_client.connect_calls == [("mqtt.example", 1883, 1)]
+        assert fake_client.loop_start_calls == 1
+        assert fake_client.loop_stop_calls == 0
+        assert fake_client.authenticated is True
 
+    asyncio.run(exercise())
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("callback_style", ["v1", "v2"])
-async def test_mqttclient_connect_raises_on_failed_authentication(callback_style):
+def test_mqttclient_connect_raises_on_failed_authentication(callback_style):
     """Generated MQTT connect() must surface auth failures instead of returning early."""
-    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
-    loop = asyncio.get_running_loop()
-    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="connect-failure", callback_style=callback_style)
-    generated_client = client_class(fake_client, loop=loop)
-    with pytest.raises(ConnectionError, match="MQTT connect failed"):
-        await generated_client.connect("mqtt.example", keepalive=1)
-    assert fake_client.loop_start_calls == 1
-    assert fake_client.loop_stop_calls == 1
-    assert fake_client.authenticated is False
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="connect-failure", callback_style=callback_style)
+        generated_client = client_class(fake_client, loop=loop)
+        with pytest.raises(ConnectionError, match="MQTT connect failed"):
+            await generated_client.connect("mqtt.example", keepalive=1)
+        assert fake_client.loop_start_calls == 1
+        assert fake_client.loop_stop_calls == 1
+        assert fake_client.authenticated is False
 
+    asyncio.run(exercise())
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("callback_style", ["v1", "v2"])
-async def test_mqttclient_connect_raises_when_disconnected_before_connack(callback_style):
+def test_mqttclient_connect_raises_when_disconnected_before_connack(callback_style):
     """Generated MQTT connect() must fail deterministically if the broker drops the connection mid-handshake."""
-    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
-    loop = asyncio.get_running_loop()
-    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="disconnect-failure", callback_style=callback_style)
-    generated_client = client_class(fake_client, loop=loop)
-    with pytest.raises(ConnectionError, match="MQTT connect failed"):
-        await generated_client.connect("mqtt.example", keepalive=1)
-    assert fake_client.loop_start_calls == 1
-    assert fake_client.loop_stop_calls == 1
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="disconnect-failure", callback_style=callback_style)
+        generated_client = client_class(fake_client, loop=loop)
+        with pytest.raises(ConnectionError, match="MQTT connect failed"):
+            await generated_client.connect("mqtt.example", keepalive=1)
+        assert fake_client.loop_start_calls == 1
+        assert fake_client.loop_stop_calls == 1
 
+    asyncio.run(exercise())
 
-@pytest.mark.asyncio
-async def test_mqttclient_connect_propagates_sync_connect_errors():
+def test_mqttclient_connect_propagates_sync_connect_errors():
     """Synchronous client.connect() failures must propagate immediately without starting the network loop."""
-    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
-    loop = asyncio.get_running_loop()
-    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="sync-error")
-    generated_client = client_class(fake_client, loop=loop)
-    with pytest.raises(OSError, match="socket setup failed"):
-        await generated_client.connect("mqtt.example", keepalive=1)
-    assert fake_client.loop_start_calls == 0
-    assert fake_client.loop_stop_calls == 0
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="sync-error")
+        generated_client = client_class(fake_client, loop=loop)
+        with pytest.raises(OSError, match="socket setup failed"):
+            await generated_client.connect("mqtt.example", keepalive=1)
+        assert fake_client.loop_start_calls == 0
+        assert fake_client.loop_stop_calls == 0
+
+    asyncio.run(exercise())
 
 
 @pytest.mark.parametrize("source_builder,document_builder", [

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -1,6 +1,7 @@
 """Test the Python code generation and integration with the generated code."""
 
 import copy
+import asyncio
 import platform
 import re
 import subprocess
@@ -566,6 +567,62 @@ def _generate_mqtt_client_src_from_document(document):
     return open(client_file, encoding="utf-8").read()
 
 
+def _load_generated_mqtt_client_module_from_document(document):
+    """Load a generated MQTT client module and return the first concrete client class."""
+    import glob
+    import types
+    import uuid
+
+    tmpdirname, client_file = _generate_python_entrypoint_from_document(document, "mqttclient", "client.py")
+    import_paths = sorted(
+        path
+        for path in glob.glob(os.path.join(tmpdirname, "**", "src"), recursive=True)
+        if os.path.isdir(path)
+    )
+    if not import_paths:
+        import_paths = sorted(
+            path
+            for path in glob.glob(os.path.join(tmpdirname, "*"))
+            if os.path.isdir(path)
+        )
+    client_src = open(client_file, encoding="utf-8").read()
+    stubbed_modules = {}
+    data_module_match = re.search(r"^import ([A-Za-z0-9_]+_data)$", client_src, re.MULTILINE)
+    if data_module_match:
+        module_name = data_module_match.group(1)
+        stub_module = types.ModuleType(module_name)
+        imported_names = re.findall(rf"^from {re.escape(module_name)} import ([A-Za-z0-9_, ]+)$", client_src, re.MULTILINE)
+        for import_group in imported_names:
+            for name in [part.strip() for part in import_group.split(",") if part.strip()]:
+                setattr(stub_module, name, type(name, (), {}))
+        stubbed_modules[module_name] = sys.modules.get(module_name)
+        sys.modules[module_name] = stub_module
+    old_sys_path = sys.path[:]
+    try:
+        for extra_path in reversed(import_paths):
+            sys.path.insert(0, extra_path)
+        module = types.ModuleType(f"generated_{uuid.uuid4().hex}")
+        module.__file__ = client_file
+        sys.modules[module.__name__] = module
+        exec(compile("from __future__ import annotations\n" + client_src, client_file, "exec"), module.__dict__)
+    finally:
+        sys.path[:] = old_sys_path
+        for module_name, previous_module in stubbed_modules.items():
+            if previous_module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = previous_module
+    client_classes = [
+        candidate
+        for candidate in vars(module).values()
+        if isinstance(candidate, type)
+        and candidate.__name__.endswith("MqttClient")
+        and candidate.__name__ != "_ClientBase"
+    ]
+    assert client_classes, f"no generated MQTT client class found in {client_file}"
+    return module, client_classes[0]
+
+
 def _generate_eh_producer_src_from_document(document):
     """Generate the Python Event Hubs producer for an inline xRegistry document."""
     _, producer_file = _generate_python_entrypoint_from_document(document, "ehproducer", "producer.py")
@@ -891,8 +948,71 @@ def _build_mqtt_time_document():
             }
         }
     }
- 
- 
+  
+
+class _DelayedMqttConnectFakeClient:
+    """Minimal fake paho client used to exercise generated async connect behavior."""
+
+    def __init__(self, loop, outcome="success", callback_style="v1", delay=0.01):
+        self.loop = loop
+        self.outcome = outcome
+        self.callback_style = callback_style
+        self.delay = delay
+        self.on_connect = None
+        self.on_disconnect = None
+        self.on_message = None
+        self.connect_calls = []
+        self.loop_start_calls = 0
+        self.loop_stop_calls = 0
+        self.disconnect_calls = 0
+        self.authenticated = False
+
+    def connect(self, broker, port, keepalive):
+        self.connect_calls.append((broker, port, keepalive))
+        if self.outcome == "sync-error":
+            raise OSError("socket setup failed")
+        if self.outcome == "success":
+            self.loop.call_later(self.delay, self._emit_connect, 0)
+        elif self.outcome == "connect-failure":
+            self.loop.call_later(self.delay, self._emit_connect, 5)
+        elif self.outcome == "disconnect-failure":
+            self.loop.call_later(self.delay, self._emit_disconnect, 7)
+        return 0
+
+    def loop_start(self):
+        self.loop_start_calls += 1
+
+    def loop_stop(self):
+        self.loop_stop_calls += 1
+
+    def disconnect(self):
+        self.disconnect_calls += 1
+
+    def subscribe(self, *args, **kwargs):
+        return (0, 1)
+
+    def unsubscribe(self, *args, **kwargs):
+        return (0,)
+
+    def publish(self, *args, **kwargs):
+        return None
+
+    def _emit_connect(self, reason_code):
+        self.authenticated = reason_code == 0
+        assert self.on_connect is not None
+        if self.callback_style == "v2":
+            self.on_connect(self, None, object(), reason_code, None)
+            return
+        self.on_connect(self, None, {}, reason_code)
+
+    def _emit_disconnect(self, reason_code):
+        assert self.on_disconnect is not None
+        if self.callback_style == "v2":
+            self.on_disconnect(self, None, object(), reason_code, None)
+            return
+        self.on_disconnect(self, None, reason_code)
+
+
 def _build_eh_time_document():
     return {
         "messagegroups": {
@@ -1164,6 +1284,63 @@ def test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation():
     assert "event_time: Optional[str] = None" in src
     assert '"{event_time}".format(event_time=event_time)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("callback_style", ["v1", "v2"])
+async def test_mqttclient_connect_waits_for_successful_authentication(callback_style):
+    """Generated MQTT connect() must not return until on_connect reports success."""
+    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+    loop = asyncio.get_running_loop()
+    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="success", callback_style=callback_style)
+    generated_client = client_class(fake_client, loop=loop)
+    await generated_client.connect("mqtt.example", keepalive=1)
+    assert fake_client.connect_calls == [("mqtt.example", 1883, 1)]
+    assert fake_client.loop_start_calls == 1
+    assert fake_client.loop_stop_calls == 0
+    assert fake_client.authenticated is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("callback_style", ["v1", "v2"])
+async def test_mqttclient_connect_raises_on_failed_authentication(callback_style):
+    """Generated MQTT connect() must surface auth failures instead of returning early."""
+    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+    loop = asyncio.get_running_loop()
+    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="connect-failure", callback_style=callback_style)
+    generated_client = client_class(fake_client, loop=loop)
+    with pytest.raises(ConnectionError, match="MQTT connect failed"):
+        await generated_client.connect("mqtt.example", keepalive=1)
+    assert fake_client.loop_start_calls == 1
+    assert fake_client.loop_stop_calls == 1
+    assert fake_client.authenticated is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("callback_style", ["v1", "v2"])
+async def test_mqttclient_connect_raises_when_disconnected_before_connack(callback_style):
+    """Generated MQTT connect() must fail deterministically if the broker drops the connection mid-handshake."""
+    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+    loop = asyncio.get_running_loop()
+    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="disconnect-failure", callback_style=callback_style)
+    generated_client = client_class(fake_client, loop=loop)
+    with pytest.raises(ConnectionError, match="MQTT connect failed"):
+        await generated_client.connect("mqtt.example", keepalive=1)
+    assert fake_client.loop_start_calls == 1
+    assert fake_client.loop_stop_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mqttclient_connect_propagates_sync_connect_errors():
+    """Synchronous client.connect() failures must propagate immediately without starting the network loop."""
+    _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+    loop = asyncio.get_running_loop()
+    fake_client = _DelayedMqttConnectFakeClient(loop, outcome="sync-error")
+    generated_client = client_class(fake_client, loop=loop)
+    with pytest.raises(OSError, match="socket setup failed"):
+        await generated_client.connect("mqtt.example", keepalive=1)
+    assert fake_client.loop_start_calls == 0
+    assert fake_client.loop_stop_calls == 0
 
 
 @pytest.mark.parametrize("source_builder,document_builder", [

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -280,6 +280,8 @@ class {{ class_name }}(_ClientBase):
         self.loop = loop
         self._topic_mappings = topic_mappings or get_default_topic_mappings_{{ groupName }}()
         self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
+        self._connect_waiter: Optional[asyncio.Future[None]] = None
+        self._connected = False
         
         # Message handler callbacks (Dispatcher pattern)
         {% for messageid, message in messagegroup.messages.items() if (message | exists("envelope","CloudEvents/1.0")) -%}
@@ -290,6 +292,72 @@ class {{ class_name }}(_ClientBase):
         
         # Attach message callback
         self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect
+        self.client.on_disconnect = self._on_disconnect
+
+    @staticmethod
+    def _mqtt_reason_code_value(reason_code) -> Optional[int]:
+        """Best-effort numeric MQTT reason-code extraction across paho callback APIs."""
+        if reason_code is None:
+            return 0
+        value = getattr(reason_code, "value", reason_code)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _mqtt_reason_code_text(reason_code) -> str:
+        """Best-effort textual MQTT reason-code rendering across paho callback APIs."""
+        if reason_code is None:
+            return "unknown"
+        text = str(reason_code).strip()
+        if text:
+            return text
+        code = _ClientBase._mqtt_reason_code_value(reason_code)
+        return str(code) if code is not None else "unknown"
+
+    def _resolve_connect_waiter(self, exc: Optional[BaseException] = None):
+        waiter = self._connect_waiter
+        self._connect_waiter = None
+        if waiter is None or waiter.done():
+            return
+        if exc is None:
+            self._connected = True
+            waiter.set_result(None)
+            return
+        self._connected = False
+        waiter.set_exception(exc)
+
+    def _notify_connect_waiter(self, exc: Optional[BaseException] = None):
+        if self.loop is None:
+            return
+        self.loop.call_soon_threadsafe(self._resolve_connect_waiter, exc)
+
+    def _on_connect(self, client, userdata, flags, reason_code=0, properties=None):
+        """Resolve a pending async connect once the broker replies."""
+        if self._mqtt_reason_code_value(reason_code) == 0:
+            self._notify_connect_waiter()
+            return
+        detail = self._mqtt_reason_code_text(reason_code)
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
+
+    def _on_disconnect(self, client, userdata, *args):
+        """Fail a pending async connect when the broker disconnects before success."""
+        self._connected = False
+        if self._connect_waiter is None:
+            return
+        reason_code = None
+        if len(args) == 1:
+            reason_code = args[0]
+        elif len(args) == 2:
+            reason_code = args[0]
+        elif len(args) >= 3:
+            reason_code = args[1]
+        detail = self._mqtt_reason_code_text(reason_code)
+        if self._mqtt_reason_code_value(reason_code) in (None, 0):
+            detail = "connection closed before authentication completed"
+        self._notify_connect_waiter(ConnectionError(f"MQTT connect failed: {detail}"))
 
     @property
     def topic_mappings(self) -> Dict[str, str]:
@@ -379,18 +447,41 @@ class {{ class_name }}(_ClientBase):
     
     async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
         """
-        Connect to MQTT broker.
+        Connect to MQTT broker and wait for authentication to complete.
 
         Args:
             broker: Broker hostname or IP
             port: Broker port
             keepalive: Keepalive interval in seconds
+
+        Raises:
+            ConnectionError: If the broker rejects the connection or disconnects before success
+            TimeoutError: If the broker does not acknowledge the connection in time
         """
-        self.client.connect(broker, port, keepalive)
-        self.client.loop_start()
+        if self._connect_waiter is not None and not self._connect_waiter.done():
+            raise RuntimeError("MQTT connect already in progress")
+        self.loop = asyncio.get_running_loop()
+        waiter = self.loop.create_future()
+        self._connect_waiter = waiter
+        self._connected = False
+        loop_started = False
+        try:
+            self.client.connect(broker, port, keepalive)
+            self.client.loop_start()
+            loop_started = True
+            timeout = float(keepalive) if keepalive and keepalive > 0 else 60.0
+            await asyncio.wait_for(waiter, timeout=timeout)
+        except Exception:
+            if self._connect_waiter is waiter:
+                self._connect_waiter = None
+            self._connected = False
+            if loop_started:
+                await asyncio.to_thread(self.client.loop_stop)
+            raise
     
     async def disconnect(self):
         """Disconnect from MQTT broker."""
+        self._connected = False
         self.client.loop_stop()
         self.client.disconnect()
 


### PR DESCRIPTION
## Summary
- make generated Python MQTT client `connect()` wait for broker authentication success instead of returning immediately
- surface auth rejection, pre-CONNACK disconnects, and synchronous connect failures deterministically
- add focused async regressions and a generated Lightbulb MQTT client test

## Testing
- `python -m pytest test\py\test_python.py -k "test_mqttclient_body_is_bytes_not_str or test_mqttclient_time_uritemplate_is_normalized_before_cloudevent_creation or test_mqttclient_connect_waits_for_successful_authentication or test_mqttclient_connect_raises_on_failed_authentication or test_mqttclient_connect_raises_when_disconnected_before_connack or test_mqttclient_connect_propagates_sync_connect_errors" > tmp\issue423-pytest.txt 2>&1`
- `python -m pytest test\py\test_python.py::test_mqttclient_lightbulb_py > tmp\issue423-generated-mqtt-pytest.txt 2>&1`

Fixes #423