### PR TITLE
Harden CI harnesses against container flake paths

### DIFF
--- a/test/KNOWN_TEST_ISSUES.md
+++ b/test/KNOWN_TEST_ISSUES.md
@@ -45,13 +45,16 @@ This document tracks tests that are temporarily skipped due to known issues.
 3. ❌ Custom wait strategy implementation - API incompatibility
 4. ❌ Removing `.withExposedPorts()` - breaks host connectivity
 
-**Workaround:** Added conditional skip logic to generated test template:
+**Workaround:** The repository's TypeScript pytest harness sets `SKIP_SERVICEBUS_TESTS=true`
+for `sbproducer` and `sbconsumer` runs on GitHub Actions unless
+`ENABLE_SERVICEBUS_TESTS=true` is explicitly set. The generated test templates honor
+that environment variable with:
 ```typescript
-const SKIP_SERVICEBUS_TESTS = process.env.CI === 'true' && process.env.ENABLE_SERVICEBUS_TESTS !== 'true';
+const SKIP_SERVICEBUS_TESTS = process.env.SKIP_SERVICEBUS_TESTS === 'true';
 const describeTest = SKIP_SERVICEBUS_TESTS ? describe.skip : describe;
 ```
 
-Tests automatically skip in CI environments unless `ENABLE_SERVICEBUS_TESTS=true` is explicitly set. This allows:
+This allows:
 - ✅ Local development testing with adequate resources
 - ✅ Manual CI runs with extended timeouts when needed  
 - ✅ Code compilation and type checking (tests still compile and build)
@@ -223,4 +226,3 @@ to:
 ```
 
 **Resolution:** All JSON Structure tests now pass across all 5 languages.
-

--- a/test/cs/test_dotnet.py
+++ b/test/cs/test_dotnet.py
@@ -15,6 +15,14 @@ sys.path.append(os.path.join(project_root))
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
+def _dotnet_test_environment() -> dict[str, str]:
+    """Return subprocess environment overrides for generated C# tests."""
+    env = os.environ.copy()
+    if IN_GITHUB_ACTIONS:
+        env.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
+    return env
+
+
 
 # this test invokes the xregistry command line tool to generate a C# proxy and a consumer
 # and then builds the proxy and the consumer and runs a prepared test that integrates both
@@ -44,7 +52,12 @@ def run_dotnet_test(xreg_file: str, output_dir: str, projectname: str, style: st
     
     # Use shell=True on Windows for .cmd files, direct execution on Linux
     use_shell = platform.system() == 'Windows'
-    subprocess.check_call(['dotnet', 'test', output_dir], cwd=os.path.dirname(__file__), shell=use_shell)
+    subprocess.check_call(
+        ['dotnet', 'test', output_dir],
+        cwd=os.path.dirname(__file__),
+        shell=use_shell,
+        env=_dotnet_test_environment(),
+    )
 
 
 def _generate_dotnet_amqp_producer_src(xreg_relpath="test/xreg/lightbulb-amqp.xreg.json"):

--- a/test/ts/test_typescript.py
+++ b/test/ts/test_typescript.py
@@ -15,6 +15,15 @@ sys.path.append(os.path.join(project_root))
 IN_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
 
+def _typescript_test_environment(style: str) -> dict[str, str]:
+    """Return subprocess environment overrides for generated TypeScript tests."""
+    env = os.environ.copy()
+    if IN_GITHUB_ACTIONS and style in {"sbproducer", "sbconsumer"}:
+        if env.get("ENABLE_SERVICEBUS_TESTS") != "true":
+            env.setdefault("SKIP_SERVICEBUS_TESTS", "true")
+    return env
+
+
 def run_typescript_test(xreg_file: str, output_dir: str, projectname: str, style: str):
     """
     Run npm test on the generated TypeScript project.
@@ -37,6 +46,7 @@ def run_typescript_test(xreg_file: str, output_dir: str, projectname: str, style
                 '--language', "ts"]
     print(f"sys.argv: {sys.argv}")
     assert xrcg.cli() == 0
+    test_env = _typescript_test_environment(style)
     
     # The generated TypeScript project is in a subdirectory based on the style
     # Map style to directory name (e.g., kafkaproducer -> TestProjectKafkaProducer)
@@ -66,16 +76,16 @@ def run_typescript_test(xreg_file: str, output_dir: str, projectname: str, style
     # First, install and build the data project if it exists
     if os.path.exists(data_project_dir):
         print(f"\n=== Installing data project in {data_project_dir} ===")
-        subprocess.check_call(['npm', 'install'], cwd=data_project_dir, shell=use_shell)
+        subprocess.check_call(['npm', 'install'], cwd=data_project_dir, shell=use_shell, env=test_env)
         
         print(f"\n=== Building data project in {data_project_dir} ===")
-        subprocess.check_call(['npm', 'run', 'build'], cwd=data_project_dir, shell=use_shell)
+        subprocess.check_call(['npm', 'run', 'build'], cwd=data_project_dir, shell=use_shell, env=test_env)
     
     # Run npm install in main project
-    subprocess.check_call(['npm', 'install'], cwd=project_dir, shell=use_shell)
+    subprocess.check_call(['npm', 'install'], cwd=project_dir, shell=use_shell, env=test_env)
     
     # Run npm test
-    subprocess.check_call(['npm', 'test'], cwd=project_dir, shell=use_shell)
+    subprocess.check_call(['npm', 'test'], cwd=project_dir, shell=use_shell, env=test_env)
 
 
 def test_kafkaproducer_contoso_erp_ts():
@@ -490,5 +500,4 @@ def test_ts_sbproducer_emits_cloudevents_prefix_not_ce_underscore():
         assert bad not in src, (
             f'ts/sbproducer must not emit non-spec CE prefix: {bad}'
         )
-
 


### PR DESCRIPTION
## Summary
- disable Testcontainers Ryuk in GitHub Actions for generated C# test runs
- skip TypeScript Service Bus generated integration tests in GitHub Actions unless explicitly enabled
- align `KNOWN_TEST_ISSUES.md` with the actual harness-based workaround

Fixes #425
Fixes #426