### PR TITLE
fix: point RabbitMQ AMQP setup links to xregistry/codegen (#464)

### DIFF
--- a/docs/rabbitmq_amqp_setup.md
+++ b/docs/rabbitmq_amqp_setup.md
@@ -661,12 +661,12 @@ If you're migrating from AMQP 0.9.1 to AMQP 1.0:
 
 - [RabbitMQ AMQP 1.0 Plugin Documentation](https://www.rabbitmq.com/plugins.html)
 - [AMQP 1.0 Specification](http://docs.oasis-open.org/amqp/core/v1.0/amqp-core-overview-v1.0.html)
-- [xRegistry CLI Documentation](https://github.com/clemensv/xregistry-cli)
+- [xRegistry CLI Documentation](https://github.com/xregistry/codegen)
 - [Apache Qpid Proton](https://qpid.apache.org/proton/) - AMQP 1.0 client library
 
 ## Support
 
 For issues specific to:
 - **RabbitMQ**: Check the [RabbitMQ mailing list](https://groups.google.com/g/rabbitmq-users)
-- **xRegistry CLI**: Open an issue on [GitHub](https://github.com/clemensv/xregistry-cli/issues)
+- **xRegistry CLI**: Open an issue on [GitHub](https://github.com/xregistry/codegen/issues)
 - **AMQP 1.0 Protocol**: Consult the [OASIS AMQP specification](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-overview-v1.0-os.html)

--- a/xrcg/templates/java/amqpconsumer/{rootdir}README.md.jinja
+++ b/xrcg/templates/java/amqpconsumer/{rootdir}README.md.jinja
@@ -24,9 +24,9 @@ This library provides a type-safe AMQP 1.0 consumer client for {{ groupname }} m
 - Apache ActiveMQ Artemis (native AMQP 1.0)
 - Apache Qpid (native AMQP 1.0)
 - Azure Service Bus (native AMQP 1.0)
-- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md))
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md))
 
-**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
 
 ## Quick Start
 

--- a/xrcg/templates/java/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/java/amqpproducer/{rootdir}README.md.jinja
@@ -19,9 +19,9 @@ Type-safe AMQP 1.0 producer client for {{ groupname }} message group using Apach
 - Apache ActiveMQ Artemis (native AMQP 1.0)
 - Apache Qpid (native AMQP 1.0)
 - Azure Service Bus (native AMQP 1.0)
-- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md))
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md))
 
-**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
 
 ## Quick Start
 

--- a/xrcg/templates/py/amqpconsumer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpconsumer/{rootdir}README.md.jinja
@@ -23,9 +23,9 @@ Use cases: Enterprise integration, IoT messaging, financial services, cloud-nati
 - Apache ActiveMQ Artemis (native AMQP 1.0)
 - Apache Qpid (native AMQP 1.0)
 - Azure Service Bus (native AMQP 1.0)
-- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md))
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md))
 
-**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
 
 ## Installation
 

--- a/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja
@@ -26,9 +26,9 @@ Use cases: Enterprise integration, IoT messaging, financial services, cloud-nati
 - Apache ActiveMQ Artemis (native AMQP 1.0)
 - Apache Qpid (native AMQP 1.0)
 - Azure Service Bus (native AMQP 1.0)
-- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md))
+- RabbitMQ (with AMQP 1.0 plugin - [setup guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md))
 
-**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/clemensv/xregistry-cli/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
+**Note for RabbitMQ users:** RabbitMQ requires the AMQP 1.0 plugin to be enabled. See the [RabbitMQ AMQP 1.0 Setup Guide](https://github.com/xregistry/codegen/blob/main/docs/rabbitmq_amqp_setup.md) for detailed instructions.
 
 {% if _azure_cbs_target %}
 ## Azure Entra ID (CBS) Authentication — enabled


### PR DESCRIPTION
## Summary

Fixes the stale RabbitMQ AMQP 1.0 setup-guide links left over from the `clemensv/xregistry-cli` -> `xregistry/codegen` repo rename. The old blob URL now returns **HTTP 404**; the corrected `xregistry/codegen` URL returns **HTTP 200** (verified).

## Changes

Replaced `clemensv/xregistry-cli` with `xregistry/codegen` in 10 occurrences across 5 files:

- `xrcg/templates/py/amqpproducer/{rootdir}README.md.jinja` (2)
- `xrcg/templates/py/amqpconsumer/{rootdir}README.md.jinja` (2)
- `xrcg/templates/java/amqpproducer/{rootdir}README.md.jinja` (2)
- `xrcg/templates/java/amqpconsumer/{rootdir}README.md.jinja` (2)
- `docs/rabbitmq_amqp_setup.md` (CLI docs + issues links, 2)

The issue named the AMQP **producer**, but the identical stale link exists in the consumer templates and in both Python and Java, so all were fixed.

## Notes

The 109 affected `*_amqp_producer/README.md` files in `clemensv/real-time-sources` are generated artifacts and will pick up the fix on regeneration with these updated templates.

Closes #464