### PR TITLE
fix: harden generated producers/clients for four codegen issues (#430, #432, #466, #467)

### DIFF
--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -969,9 +969,11 @@ class _DelayedMqttConnectFakeClient:
         self.loop_stop_calls = 0
         self.disconnect_calls = 0
         self.authenticated = False
+        self.connect_properties = None
 
-    def connect(self, broker, port, keepalive):
+    def connect(self, broker, port, keepalive, properties=None):
         self.connect_calls.append((broker, port, keepalive))
+        self.connect_properties = properties
         if self.outcome == "sync-error":
             raise OSError("socket setup failed")
         if self.outcome == "success":
@@ -1110,6 +1112,29 @@ def test_kafkaproducer_time_uritemplate_is_normalized_before_cloudevent_creation
     assert '"{event_time}".format(event_time=_event_time)' in src
     assert 'attributes["time"] = _resolve_cloudevents_time(_time, attributes.get("time"))' in src
     assert "data_marshaller=lambda x: self.__binary_data_marshaller(x)" in src
+
+
+def test_kafkaproducer_exposes_resilient_flush_helper():
+    """Regression for #430: the generated Kafka producer must expose a
+    ``flush(timeout, retries, backoff_factor)`` helper that retries with
+    exponential backoff and raises RuntimeError when messages remain unsent,
+    so bridges no longer hand-roll flush-with-retry boilerplate around brokers
+    that drop idle connections (Azure Event Hubs, Confluent Cloud, ...).
+    """
+    src = _generate_kafka_producer_src_from_document(_build_kafka_time_document())
+    # Module must stay syntactically valid with the new method.
+    compile(src, "<generated kafka producer.py>", "exec")
+    assert "import time" in src
+    assert (
+        "def flush(self, timeout: float = 30, retries: int = 3, "
+        "backoff_factor: float = 2.0) -> None:"
+    ) in src
+    # Retry loop with exponential backoff and a hard failure after exhaustion.
+    assert "for attempt in range(1, retries + 1):" in src
+    assert "remaining = self.producer.flush(timeout)" in src
+    assert "time.sleep(backoff_factor ** attempt)" in src
+    assert "raise RuntimeError(" in src
+    assert "Kafka flush left" in src
 
 
 def test_amqpproducer_body_is_bytes_with_inferred_true():
@@ -1252,6 +1277,129 @@ def test_amqpproducer_time_uritemplate_sets_ce_and_creation_time():
     assert "amqp_msg.creation_time = amqp_creation_time" in src
 
 
+def _build_amqp_protocol_option_time_document():
+    """Manifest reproducing issue #466: a protocol-option uritemplate whose
+    placeholder is literally named ``time``. That placeholder is emitted as a
+    ``_time`` parameter, colliding with the reserved CloudEvents ``_time``
+    override the AMQP producer always injects.
+    """
+    return {
+        "messagegroups": {
+            "Example.Amqp": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "AMQP/1.0",
+                "messages": {
+                    "Example.Event": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "AMQP/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "Example.Event"},
+                            "source": {"type": "uritemplate", "value": "{feedurl}"},
+                            "datacontenttype": {"value": "application/json"},
+                        },
+                        "protocoloptions": {
+                            "properties": {
+                                "subject": {
+                                    "type": "uritemplate",
+                                    "value": "jp.tepco.denkiyoho/{date}/{time}",
+                                }
+                            },
+                            "message_annotations": {
+                                "x-opt-partition-key": {
+                                    "type": "uritemplate",
+                                    "value": "jp.tepco.denkiyoho/{date}/{time}",
+                                }
+                            },
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_amqpproducer_protocol_option_time_placeholder_does_not_collide_with_reserved_time():
+    """Regression for #466: a protocol-option (or envelope) placeholder named
+    ``time`` must not emit a second ``_time`` parameter. The duplicate argument
+    made the generated module unimportable with
+    ``SyntaxError: duplicate argument '_time' in function definition``.
+    """
+    src = _generate_amqp_producer_src_from_document(
+        _build_amqp_protocol_option_time_document()
+    )
+    # The whole module must be syntactically valid. This is the exact failure
+    # mode #466 reports: a duplicate ``_time`` arg (and the matching duplicate
+    # keyword in the batch fan-out call) raises SyntaxError at import time.
+    compile(src, "<generated amqp producer.py>", "exec")
+    sig_start = src.index("def send_event(")
+    sig_end = src.index(") -> None:", sig_start)
+    send_signature = src[sig_start:sig_end]
+    # Exactly one reserved CloudEvents time override -- no duplicate from {time}.
+    assert send_signature.count("_time:") == 1
+    # The non-reserved placeholder is still surfaced as a parameter.
+    assert send_signature.count("_date: str") == 1
+    # The {time} placeholder still resolves, binding to the reserved _time arg.
+    assert "time=_time" in src
+
+
+def _build_amqp_map_key_differs_from_type_document():
+    """Map key carries a transport infix ('.amqp.') but the CloudEvents type
+    resolves to a transport-independent value -- reproducing #467.
+    """
+    return {
+        "messagegroups": {
+            "JP.TEPCO.Denkiyoho": {
+                "envelope": "CloudEvents/1.0",
+                "protocol": "AMQP/1.0",
+                "messages": {
+                    "JP.TEPCO.Denkiyoho.amqp.Info": {
+                        "envelope": "CloudEvents/1.0",
+                        "protocol": "AMQP/1.0",
+                        "envelopemetadata": {
+                            "type": {"value": "JP.TEPCO.Denkiyoho.Info"},
+                            "source": {"value": "urn:test"},
+                            "datacontenttype": {"value": "application/json"},
+                        },
+                        "dataschemaformat": "JsonSchema/draft-07",
+                        "dataschema": {
+                            "type": "object",
+                            "properties": {"value": {"type": "string"}},
+                        },
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_amqpproducer_test_asserts_resolved_ce_type_not_map_key():
+    """Regression for #467: the generated producer integration test must assert
+    the CloudEvents ``type`` against the resolved ``envelopemetadata.type.value``,
+    not the (possibly transport-infixed) ``messages`` map key.
+    """
+    _, test_file = _generate_python_entrypoint_from_document(
+        _build_amqp_map_key_differs_from_type_document(), "amqpproducer", "test_producer.py"
+    )
+    test_src = open(test_file, encoding="utf-8").read()
+    type_assertion_lines = [
+        line
+        for line in test_src.splitlines()
+        if "assert" in line and "type" in line and "==" in line
+    ]
+    assert type_assertion_lines, "expected at least one CloudEvents type assertion"
+    assert all(
+        "JP.TEPCO.Denkiyoho.amqp.Info" not in line for line in type_assertion_lines
+    ), "generated test must not assert the transport-infixed map key as the CloudEvents type"
+    assert any(
+        "JP.TEPCO.Denkiyoho.Info" in line for line in type_assertion_lines
+    ), "generated test must assert the resolved envelopemetadata.type.value"
+
+
 def test_mqttclient_body_is_bytes_not_str():
     """The MQTT PUBLISH payload MUST be bytes. ``to_byte_array`` returns
     ``str`` for text content types; the client must coerce to bytes
@@ -1347,6 +1495,39 @@ def test_mqttclient_connect_propagates_sync_connect_errors():
             await generated_client.connect("mqtt.example", keepalive=1)
         assert fake_client.loop_start_calls == 0
         assert fake_client.loop_stop_calls == 0
+
+    asyncio.run(exercise())
+
+
+def test_mqttclient_connect_uses_mqtt_v5_enhanced_auth_for_token():
+    """Regression for #432: a bearer token passed to connect() must be presented
+    via MQTT v5 Enhanced Authentication (OAUTH2-JWT) CONNECT properties, not as a
+    username/password (which silently fails CONNACK against Azure Event Grid and
+    leaves publish() queueing locally)."""
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="success")
+        generated_client = client_class(fake_client, loop=loop)
+        await generated_client.connect("mqtt.example", token="header.payload.signature", keepalive=1)
+        props = fake_client.connect_properties
+        assert props is not None, "connect() must send MQTT v5 CONNECT properties when a token is supplied"
+        assert getattr(props, "AuthenticationMethod", None) == "OAUTH2-JWT"
+        assert getattr(props, "AuthenticationData", None) == b"header.payload.signature"
+
+    asyncio.run(exercise())
+
+
+def test_mqttclient_connect_without_token_sends_no_properties():
+    """The default (token-less) connect path must remain unchanged so it keeps
+    working with MQTT v3.1.1 clients that reject CONNECT properties."""
+    async def exercise():
+        _, client_class = _load_generated_mqtt_client_module_from_document(_build_mqtt_time_document())
+        loop = asyncio.get_running_loop()
+        fake_client = _DelayedMqttConnectFakeClient(loop, outcome="success")
+        generated_client = client_class(fake_client, loop=loop)
+        await generated_client.connect("mqtt.example", keepalive=1)
+        assert fake_client.connect_properties is None
 
     asyncio.run(exercise())
 

--- a/test/py/test_python.py
+++ b/test/py/test_python.py
@@ -1347,6 +1347,49 @@ def test_amqpproducer_protocol_option_time_placeholder_does_not_collide_with_res
     assert "time=_time" in src
 
 
+def _build_nontime_time_placeholder_document(document_builder):
+    """Take a per-style time document and force a ``{time}`` placeholder into a
+    non-time attribute (``source``). That placeholder would otherwise be emitted
+    as a second ``_time`` parameter, colliding with the reserved CloudEvents
+    ``_time`` override every producer injects (issue #466).
+    """
+    document = copy.deepcopy(document_builder())
+    messagegroup = next(iter(document["messagegroups"].values()))
+    message = next(iter(messagegroup["messages"].values()))
+    message["envelopemetadata"]["source"] = {
+        "type": "uritemplate",
+        "value": "/feed/{date}/{time}",
+    }
+    return document
+
+
+@pytest.mark.parametrize("source_builder,document_builder", [
+    (_generate_kafka_producer_src_from_document, _build_kafka_time_document),
+    (_generate_amqp_producer_src_from_document, _build_amqp_time_document),
+    (_generate_eh_producer_src_from_document, _build_eh_time_document),
+    (_generate_sb_producer_src_from_document, _build_sb_time_document),
+])
+def test_generated_py_nontime_time_placeholder_does_not_collide_with_reserved_time(source_builder, document_builder):
+    """Regression for #466 across producer styles: a ``{time}`` placeholder in a
+    non-time uritemplate attribute must not emit a second ``_time`` parameter.
+    The duplicate argument made the generated module unimportable with
+    ``SyntaxError: duplicate argument '_time' in function definition``.
+    """
+    src = source_builder(_build_nontime_time_placeholder_document(document_builder))
+    # The whole module must be syntactically valid -- the exact #466 failure mode.
+    compile(src, "<generated producer.py>", "exec")
+    # The reserved CloudEvents time override is present (>=1: some styles emit a
+    # batch fan-out method alongside the single send). compile() above already
+    # guarantees no duplicate _time *within* any one signature.
+    assert src.count("_time: typing.Optional[typing.Union[str, datetime]]") >= 1
+    # The {time} placeholder must NOT be surfaced as its own ``_time`` parameter.
+    assert "_time : str" not in src and "_time: str" not in src
+    # The sibling {date} placeholder is still surfaced as a parameter.
+    assert "_date" in src
+    # The {time} placeholder still resolves, binding to the reserved _time arg.
+    assert "time=_time" in re.sub(r"\s", "", src)
+
+
 def _build_amqp_map_key_differs_from_type_document():
     """Map key carries a transport infix ('.amqp.') but the CloudEvents type
     resolves to a transport-independent value -- reproducing #467.

--- a/xrcg/templates/cs/_common/cloudevents.jinja.include
+++ b/xrcg/templates/cs/_common/cloudevents.jinja.include
@@ -178,7 +178,8 @@ switch (cloudEventType)
 {
     {% for messageid, message in messagegroup.messages.items() -%}
     {% set messagename = messageid | pascal %}
-    case "{{ messageid }}":
+    {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+    case "{{ ce_type_value }}":
         if ( this.{{ messagegroupid | strip_namespace | camel }}Dispatcher != null )
         {
             await this.{{ messagegroupid | strip_namespace | camel }}Dispatcher.On{{ messagename | strip_namespace }}Async({{ cloudEvent }},
@@ -206,7 +207,8 @@ switch (cloudEventType)
     {% for messagegroupid, messagegroup in messagegroups.items() if (messagegroup | exists("envelope","CloudEvents/1.0")) -%}
     {% for messageid, message in messagegroup.messages.items() -%}
     {% set messagename = messageid | pascal %}
-    case "{{ messageid }}":
+    {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+    case "{{ ce_type_value }}":
         if ( this.{{ messagegroupid  | strip_namespace | camel }}Dispatcher != null )
         {
             await this.{{ messagegroupid  | strip_namespace | camel }}Dispatcher.On{{ messagename | strip_namespace }}Async({{ cloudEvent }},

--- a/xrcg/templates/cs/amqpproducer/test/AmqpProducerTest.cs.jinja
+++ b/xrcg/templates/cs/amqpproducer/test/AmqpProducerTest.cs.jinja
@@ -443,7 +443,7 @@ namespace {{ project_name | pascal }}.Test
                                                 // Verify CloudEvents properties
                                                 Assert.NotNull(receivedMessage.ApplicationProperties);
                                                 Assert.Equal("1.0", receivedMessage.ApplicationProperties["cloudEvents:specversion"]);
-                                                Assert.Equal("{{ messageid }}", receivedMessage.ApplicationProperties["cloudEvents:type"]);
+                                                Assert.Equal("{{ message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid }}", receivedMessage.ApplicationProperties["cloudEvents:type"]);
                                                 Assert.NotNull(receivedMessage.ApplicationProperties["cloudEvents:id"]);
                                                 Assert.NotNull(receivedMessage.ApplicationProperties["cloudEvents:source"]);
                                                 

--- a/xrcg/templates/cs/ehazfn/test/FunctionTest.cs.jinja
+++ b/xrcg/templates/cs/ehazfn/test/FunctionTest.cs.jinja
@@ -74,6 +74,7 @@ namespace {{ project_name | pascal }}.Tests
         {%- if message.envelope.startswith("CloudEvents") -%}     
         {%- set messagename = messageid | pascal %}
         {%- set message_body_type = util.body_type(data_project_name, root, message) -%}
+        {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
         [Test]
         public async Task Run_With{{ messageid | strip_namespace | pascal }}_ShouldInvoke{{ messagegroupid | strip_namespace | pascal }}DispatcherOn{{ messageid | strip_namespace | pascal }}Async()
         {
@@ -85,7 +86,7 @@ namespace {{ project_name | pascal }}.Tests
             var eventData = new EventData(new BinaryData(""));
             {%- endif %}
             eventData.Properties.Add("cloudEvents:specversion", "1.0");
-            eventData.Properties.Add("cloudEvents_type", "{{ messageid }}");
+            eventData.Properties.Add("cloudEvents_type", "{{ ce_type_value }}");
             eventData.ContentType = "application/json";
             var events = new[] { eventData };
             await {{ function_class_field }}.Run(events, loggerMock.Object);

--- a/xrcg/templates/cs/sbazfn/test/FunctionTest.cs.jinja
+++ b/xrcg/templates/cs/sbazfn/test/FunctionTest.cs.jinja
@@ -84,6 +84,7 @@ namespace {{ project_name | pascal }}.Tests
         {%- for messageid, message in messagegroup.messages.items() -%}
         {%- if message.envelope.startswith("CloudEvents") -%}     
         {%- set messagename = messageid | pascal %}
+        {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
         [Test]
         public async Task Run_With{{ messageid | strip_namespace | pascal }}_ShouldInvoke{{ messagegroupid | strip_namespace | pascal }}DispatcherOn{{ messageid | strip_namespace | pascal }}Async()
         {
@@ -97,7 +98,7 @@ namespace {{ project_name | pascal }}.Tests
                 properties: new Dictionary<string, object>
                 {
                     {"cloudEvents_specversion", "1.0"},
-                    {"cloudEvents_type", "{{ messageid }}"}
+                    {"cloudEvents_type", "{{ ce_type_value }}"}
                 }
             );
             {%- else %}
@@ -107,7 +108,7 @@ namespace {{ project_name | pascal }}.Tests
                 properties: new Dictionary<string, object>
                 {
                     {"cloudEvents:specversion", "1.0"},
-                    {"cloudEvents_type", "{{ messageid }}"}
+                    {"cloudEvents_type", "{{ ce_type_value }}"}
                 }
             );
             {%- endif %}

--- a/xrcg/templates/java/_common/cloudevents.jinja.include
+++ b/xrcg/templates/java/_common/cloudevents.jinja.include
@@ -130,7 +130,7 @@ switch (eventType) {
 {%- for messagegroupid, messagegroup in messagegroups.items() if (messagegroup | exists("envelope","CloudEvents/1.0")) -%}
 {%- for messageid, message in messagegroup.messages.items() -%}
 {%- set messagename = messageid | pascal | strip_namespace %}
-    case "{{ messageid }}":
+    case "{{ message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid }}":
         if ({{ messagegroupid | strip_namespace | camel }}Dispatcher != null) {
             {%- if message.dataschemauri or message.dataschema -%}
             {%- set type = (message.dataschemauri if message.dataschemauri else message.dataschema) | schema_type(project_name, root, message.dataschemaformat) %}

--- a/xrcg/templates/py/amqpconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
+++ b/xrcg/templates/py/amqpconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
@@ -339,8 +339,9 @@ class {{ class_name }}:
         {%- set messagename = messageid | strip_dots | pascal %}
         {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
         {%- set message_body_type = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
+        {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
         {%- if isCloudEvent %}
-        if cloud_event_type == '{{ messageid }}':
+        if cloud_event_type == '{{ ce_type_value }}':
             if self.{{ messagename | snake }}_handler:
                 {%- if message_body_type == 'object' %}
                 # No data schema defined for this message

--- a/xrcg/templates/py/amqpconsumer/{testdir}test_dispatcher.py.jinja
+++ b/xrcg/templates/py/amqpconsumer/{testdir}test_dispatcher.py.jinja
@@ -334,7 +334,8 @@ class Test{{ class_name }}:
         for i in range(5):
             {%- if isCloudEvent %}
             msg.properties = {
-                "cloudEvents:type": "{{ messageid }}",
+                {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+                "cloudEvents:type": "{{ ce_type_value }}",
                 "cloudEvents:specversion": "1.0",
                 "cloudEvents:source": "test",
                 "cloudEvents:id": f"test-{i}"

--- a/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -762,7 +762,7 @@ class {{ class_name }}:
     {%- for propname, prop in propmap.items() if prop.value is defined %}
     {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
     {%- set argname = placeholder | snake %}
-    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items %}
+    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items and argname != 'time' %}
     {%- set _ = protocol_option_arg_names.items.append(argname) %}
     {%- endif %}
     {%- endfor %}
@@ -772,7 +772,7 @@ class {{ class_name }}:
     {%- if isCloudEvent and 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value %}
     {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
     {%- set argname = placeholder | snake %}
-    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items and argname not in time_arg_names.items %}
+    {%- if argname not in ce_arg_names.items and argname not in protocol_option_arg_names.items and argname not in time_arg_names.items and argname != 'time' %}
     {%- set _ = time_arg_names.items.append(argname) %}
     {%- endif %}
     {%- endfor %}
@@ -785,7 +785,7 @@ class {{ class_name }}:
         _{{ attrname }}: str,
         {%- endfor %}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
-        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}
         _{{ placeholder | snake }}: str,
         {%- endfor %}
         {%- endfor %}
@@ -954,7 +954,7 @@ class {{ class_name }}:
         _{{ attrname }}: str,
         {%- endfor %}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
-        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}
         _{{ placeholder | snake }}: str,
         {%- endfor %}
         {%- endfor %}
@@ -1005,7 +1005,7 @@ class {{ class_name }}:
                 _{{ attrname }}=_{{ attrname }},
                 {%- endfor %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
-                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}
                 _{{ placeholder | snake }}=_{{ placeholder | snake }},
                 {%- endfor %}
                 {%- endfor %}

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -382,7 +382,7 @@ class Test{{ class_name }}:
             {%- if isCloudEvent %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
                     {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
-                        {%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}
+                        {%- if (placeholder | snake) != 'time' %}{%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}{%- endif %}
                     {%- endfor %}
                 {%- endfor %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
@@ -393,7 +393,7 @@ class Test{{ class_name }}:
                 {%- for propname, prop in propmap.items() if prop.value is defined %}
                     {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
                         {%- set arg = '_' + (placeholder | snake) %}
-                        {%- if arg not in extra_args.items %}
+                        {%- if arg not in extra_args.items and (placeholder | snake) != 'time' %}
                             {%- set _ = extra_args.items.append(arg) %}
                         {%- endif %}
                     {%- endfor %}
@@ -486,7 +486,7 @@ class Test{{ class_name }}:
             {%- if isCloudEvent %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" %}
                     {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
-                        {%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}
+                        {%- if (placeholder | snake) != 'time' %}{%- set _ = extra_args.items.append('_' + (placeholder | snake)) %}{%- endif %}
                     {%- endfor %}
                 {%- endfor %}
                 {%- for attrname, attribute in message.envelopemetadata.items() if attribute.value is not defined and attrname not in ["time", "id", "datacontenttype", "dataschema"] %}
@@ -497,7 +497,7 @@ class Test{{ class_name }}:
                 {%- for propname, prop in propmap.items() if prop.value is defined %}
                     {%- for placeholder in prop.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
                         {%- set arg = '_' + (placeholder | snake) %}
-                        {%- if arg not in extra_args.items %}
+                        {%- if arg not in extra_args.items and (placeholder | snake) != 'time' %}
                             {%- set _ = extra_args.items.append(arg) %}
                         {%- endif %}
                     {%- endfor %}

--- a/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/amqpproducer/{testdir}test_producer.py.jinja
@@ -333,6 +333,7 @@ class Test{{ class_name }}:
     
     {%- for messageid, message in messagegroup.messages.items() %}
     {%- set messagename = messageid | pascal | strip_namespace %}
+    {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
     {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
     {%- set type_name = util.DeclareDataType( data_project_name, root, message ) | strip_namespace %}
     {%- set group_protocoloptions = messagegroup.protocoloptions if messagegroup.protocoloptions is defined and messagegroup.protocoloptions else {} %}
@@ -428,7 +429,7 @@ class Test{{ class_name }}:
                     else:
                         body_text = str(body)
                     cloud_event_payload = json.loads(body_text)
-                    assert cloud_event_payload.get("type") == "{{ messageid }}"
+                    assert cloud_event_payload.get("type") == "{{ ce_type_value }}"
                     # Verify data section exists (either as data or data_base64)
                     assert "data" in cloud_event_payload or "data_base64" in cloud_event_payload
                 else:
@@ -518,7 +519,7 @@ class Test{{ class_name }}:
         annotations = received.annotations or {}
 
         {%- if isCloudEvent %}
-        assert properties.get('cloudEvents:type') == '{{ messageid }}'
+        assert properties.get('cloudEvents:type') == '{{ ce_type_value }}'
         {%- else %}
         {%- if ('subject' not in message_properties) and ('subject' not in message_application_properties) %}
         assert properties.get('subject') == '{{ messageid }}'

--- a/xrcg/templates/py/ehconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
+++ b/xrcg/templates/py/ehconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
@@ -293,7 +293,8 @@ class {{ class_name }}(_DispatcherBase):
             {%- set message_id = messageid %}
             {%- set is_cloudevent = (message | exists("envelope","CloudEvents/1.0")) %}
             {%- set data_type = util.DeclareDataType(data_project_name, root, message) %}
-            "{{ messageid }}": lambda: self.{{ messageid | dotunderscore | snake }}_async(partition_context, event, cloud_event,
+            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+            "{{ ce_type_value }}": lambda: self.{{ messageid | dotunderscore | snake }}_async(partition_context, event, cloud_event,
             {%- if data_type != "object" %}
                 {{ data_type | strip_namespace }}.from_data(cloud_event.data, cloud_event["datacontenttype"])
             {%- else %}

--- a/xrcg/templates/py/ehconsumer/{testdir}test_dispatcher.py.jinja
+++ b/xrcg/templates/py/ehconsumer/{testdir}test_dispatcher.py.jinja
@@ -197,7 +197,8 @@ async def {{ test_function_name | dotunderscore }}(event_hub_emulator):
         event_data.content_type = "application/json"
         {%- if isCloudEvent %}
         event_data.properties = {
-            "cloudEvents_type": "{{ messageid }}",
+            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+            "cloudEvents_type": "{{ ce_type_value }}",
             "cloudEvents_specversion": "1.0",
             "cloudEvents_source": "/test",
             "cloudEvents_id": "test-id"

--- a/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -57,13 +57,13 @@ class {{ class_name }}:
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
     {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
-        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
+        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
     {%- set time_placeholder_params = [] -%}
     {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
         {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
             {%- set placeholder_name = placeholder | snake -%}
-            {%- if placeholder_name not in time_placeholder_params -%}
+            {%- if placeholder_name not in time_placeholder_params and placeholder_name != 'time' -%}
                 {%- set _ = time_placeholder_params.append(placeholder_name) -%}
             {%- endif -%}
         {%- endfor -%}

--- a/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
@@ -178,7 +178,7 @@ async def {{ test_function_name | dotunderscore }}(event_hub_emulator):
                 _{{ attrname }} = f'test_{{ attrname }}_{i}',
             {%- endfor -%}
             {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' -%}
-                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
+                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
             {%- endfor -%}
             _time = datetime.datetime.now(datetime.timezone.utc).isoformat(),
             data = event_data

--- a/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/ehproducer/{testdir}test_producer.py.jinja
@@ -151,7 +151,7 @@ async def {{ test_function_name | dotunderscore }}(event_hub_emulator):
     async def on_event(partition_context, event):
         nonlocal received_count
         try:
-            assert event.properties["cloudEvents_type".encode('utf-8')] == "{{ messageid }}".encode('utf-8')
+            assert event.properties["cloudEvents_type".encode('utf-8')] == "{{ message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid }}".encode('utf-8')
             await partition_context.update_checkpoint(event)
             received_count += 1
             if received_count >= 5:

--- a/xrcg/templates/py/kafkaconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
+++ b/xrcg/templates/py/kafkaconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
@@ -311,7 +311,8 @@ class {{ class_name }}(DispatcherBase):
             {%- set message_id = messageid %}
             {%- set isCloudEvent = (message | exists("envelope","CloudEvents/1.0")) %}
             {%- set dataType = util.DeclareDataType( data_project_name, root, message ) %}
-            "{{ messageid }}": lambda: self.{{ messageid | dotunderscore | snake }}_async(consumer, message, cloud_event,
+            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+            "{{ ce_type_value }}": lambda: self.{{ messageid | dotunderscore | snake }}_async(consumer, message, cloud_event,
             {%- if dataType != "object" %}
                 {{ dataType | strip_namespace }}.from_data(cloud_event.data, cloud_event["datacontenttype"])
             {%- else %}

--- a/xrcg/templates/py/kafkaconsumer/{testdir}test_dispatcher.py.jinja
+++ b/xrcg/templates/py/kafkaconsumer/{testdir}test_dispatcher.py.jinja
@@ -118,7 +118,8 @@ async def {{ test_function_name | dotunderscore }}(kafka_emulator):
         # Send 5 messages to test proper message settlement and ordering
         for i in range(5):
             producer.produce(topic='test_topic', key=b'abc', value=event_data, headers=[
-                ("ce_type", b"{{ messageid }}"),
+                {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+                ("ce_type", b"{{ ce_type_value }}"),
                 ("ce_specversion", b"1.0"),
                 ("ce_source", b"/test"),
                 ("ce_id", f"test-id-{i}".encode('utf-8')),

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -120,7 +120,7 @@ class {{ class_name }}:
     {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
         {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
             {%- set placeholder_name = placeholder | snake -%}
-            {%- if placeholder_name not in declared_params and placeholder_name not in kafka_key_param_names and placeholder_name not in time_placeholder_params -%}
+            {%- if placeholder_name not in declared_params and placeholder_name not in kafka_key_param_names and placeholder_name not in time_placeholder_params and placeholder_name != 'time' -%}
                 {%- set _ = time_placeholder_params.append(placeholder_name) -%}
             {%- endif -%}
         {%- endfor -%}
@@ -134,11 +134,11 @@ class {{ class_name }}:
         _{{ attrname }}: str, {{ '' }}
         {%- endfor -%}
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
-            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
+            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}_{{ placeholder | snake }} : str, {% endfor -%}
         {%- endfor -%}
         {%- if kafka_key_value -%}
             {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
-                {%- if (placeholder | snake) not in declared_params %}_{{ placeholder | snake }}: str, {% endif -%}
+                {%- if (placeholder | snake) not in declared_params and (placeholder | snake) != 'time' %}_{{ placeholder | snake }}: str, {% endif -%}
             {%- endfor -%}
         {%- endif -%}
         data: {{ data_type | strip_namespace -}}, content_type: str = "application/json"

--- a/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -3,6 +3,7 @@
 
 # pylint: disable=unused-import, line-too-long, missing-module-docstring, missing-function-docstring, missing-class-docstring, consider-using-f-string, trailing-whitespace, trailing-newlines
 import sys
+import time
 import json
 import re
 import uuid
@@ -235,6 +236,35 @@ class {{ class_name }}:
         if flush_producer:
             self.producer.flush()
 {% endfor %}
+
+    def flush(self, timeout: float = 30, retries: int = 3, backoff_factor: float = 2.0) -> None:
+        """Flush pending messages with retry and exponential backoff.
+
+        Brokers that drop idle connections (e.g. Azure Event Hubs, Confluent
+        Cloud) can make a single ``flush()`` fail right after a reconnect, so a
+        bare ``flush(timeout)`` is not resilient on its own. This retries the
+        flush, sleeping ``backoff_factor ** attempt`` seconds between attempts,
+        and raises ``RuntimeError`` if any messages remain unsent after all
+        attempts.
+
+        Args:
+            timeout (float): Seconds to wait for each underlying flush attempt.
+            retries (int): Maximum number of flush attempts.
+            backoff_factor (float): Base of the exponential backoff between attempts.
+
+        Raises:
+            RuntimeError: If messages remain unsent after all retries.
+        """
+        for attempt in range(1, retries + 1):
+            remaining = self.producer.flush(timeout)
+            if remaining == 0:
+                return
+            if attempt < retries:
+                time.sleep(backoff_factor ** attempt)
+            else:
+                raise RuntimeError(
+                    f"Kafka flush left {remaining} message(s) unsent after {retries} attempt(s)."
+                )
 
     @classmethod
     def parse_connection_string(cls, connection_string: str) -> typing.Tuple[typing.Dict[str, str], str]:

--- a/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
@@ -172,7 +172,7 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
                 _{{ attrname }} = f'test_{i}',
             {%- endfor -%}
             {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' -%}
-                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
+                {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}_{{ placeholder | snake }} = f'test_{i}', {% endfor -%}
             {%- endfor -%}
             {%- if kafka_key_value -%}
                 {%- for placeholder in kafka_key_value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}

--- a/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/kafkaproducer/{testdir}test_producer.py.jinja
@@ -152,7 +152,7 @@ def {{ test_function_name | dotunderscore }}(kafka_emulator):
             if msg.error():
                 continue
             cloudevent = parse_cloudevent(msg)
-            if cloudevent['type'] == "{{ messageid }}":
+            if cloudevent['type'] == "{{ message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid }}":
                 return msg.key().decode('utf-8') if msg.key() else None
 
     kafka_producer = Producer({'bootstrap.servers': bootstrap_servers})

--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -444,8 +444,40 @@ class {{ class_name }}(_ClientBase):
         """
         for topic in topics:
             self.client.unsubscribe(topic)
-    
-    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60):
+
+    @staticmethod
+    def _build_enhanced_auth_properties(token, authentication_method: str = "OAUTH2-JWT", base=None):
+        """Build MQTT v5 CONNECT properties carrying an OAuth2/Entra JWT via
+        MQTT v5 Enhanced Authentication.
+
+        Azure Event Grid Namespaces (and other Entra-secured MQTT v5 brokers)
+        require the bearer token to be presented through the CONNECT
+        ``Authentication Method`` / ``Authentication Data`` properties, NOT the
+        username/password fields. Username/password silently fails CONNACK and
+        ``publish()`` then queues messages locally without ever reaching the
+        broker. See
+        https://learn.microsoft.com/azure/event-grid/mqtt-client-microsoft-entra-token-and-rbac
+
+        The paho client passed to this class MUST be created with
+        ``protocol=mqtt.MQTTv5`` for these properties to be honored.
+        """
+        if not _MQTT5_AVAILABLE:
+            raise RuntimeError(
+                "MQTT v5 Enhanced Authentication (OAUTH2-JWT) requires "
+                "paho-mqtt >= 2.0; install a newer paho-mqtt to use "
+                "token-based auth."
+            )
+        connect_properties = base if base is not None else _MqttProperties(_MqttPacketTypes.CONNECT)
+        connect_properties.AuthenticationMethod = authentication_method
+        connect_properties.AuthenticationData = (
+            token.encode("utf-8") if isinstance(token, str) else token
+        )
+        return connect_properties
+
+    async def connect(self, broker: str, port: int = 1883, keepalive: int = 60,
+                      token: Optional[str] = None,
+                      authentication_method: str = "OAUTH2-JWT",
+                      properties: Optional["_MqttProperties"] = None):
         """
         Connect to MQTT broker and wait for authentication to complete.
 
@@ -453,6 +485,16 @@ class {{ class_name }}(_ClientBase):
             broker: Broker hostname or IP
             port: Broker port
             keepalive: Keepalive interval in seconds
+            token: Optional OAuth2/Entra bearer token (JWT). When provided, it is
+                presented via MQTT v5 Enhanced Authentication
+                (Authentication Method ``OAUTH2-JWT`` + Authentication Data) as
+                required by Azure Event Grid Namespaces -- NOT as a password.
+                Requires a paho client created with ``protocol=mqtt.MQTTv5``.
+            authentication_method: MQTT v5 Authentication Method to advertise
+                when ``token`` is supplied (default ``OAUTH2-JWT``).
+            properties: Optional MQTT v5 CONNECT ``Properties`` to send. When
+                ``token`` is also supplied, the enhanced-auth fields are set on
+                these properties.
 
         Raises:
             ConnectionError: If the broker rejects the connection or disconnects before success
@@ -466,7 +508,15 @@ class {{ class_name }}(_ClientBase):
         self._connected = False
         loop_started = False
         try:
-            self.client.connect(broker, port, keepalive)
+            connect_properties = properties
+            if token is not None:
+                connect_properties = self._build_enhanced_auth_properties(
+                    token, authentication_method, base=properties
+                )
+            if connect_properties is not None:
+                self.client.connect(broker, port, keepalive, properties=connect_properties)
+            else:
+                self.client.connect(broker, port, keepalive)
             self.client.loop_start()
             loop_started = True
             timeout = float(keepalive) if keepalive and keepalive > 0 else 60.0

--- a/xrcg/templates/py/sbconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
+++ b/xrcg/templates/py/sbconsumer/src/{mainprojectdir!dotunderscore!lower}dispatcher.py.jinja
@@ -258,8 +258,9 @@ class {{ class_name }}(_DispatcherBase):
         {%- for messageid, message in messagegroup.messages.items() %}
         {%- set is_cloudevent = (message | exists("envelope","CloudEvents/1.0")) %}
         {%- set data_type = util.DeclareDataType(data_project_name, root, message) %}
+        {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
         {%- if is_cloudevent %}
-        if cloud_event_type == "{{ messageid }}":
+        if cloud_event_type == "{{ ce_type_value }}":
             try:
                 {%- if data_type != "object" %}
                 data = {{ data_type | strip_namespace }}.from_data(cloud_event.data, cloud_event["datacontenttype"])
@@ -269,7 +270,7 @@ class {{ class_name }}(_DispatcherBase):
                 await self.{{ messageid | dotunderscore | snake }}_async(message, cloud_event, data)
                 return
             except Exception as e:
-                raise RuntimeError(f"Failed to process CloudEvent type '{{ messageid }}': {e}") from e
+                raise RuntimeError(f"Failed to process CloudEvent type '{{ ce_type_value }}': {e}") from e
         {%- endif %}
         {%- endfor %}
         

--- a/xrcg/templates/py/sbconsumer/{testdir}test_consumer.py.jinja
+++ b/xrcg/templates/py/sbconsumer/{testdir}test_consumer.py.jinja
@@ -177,9 +177,10 @@ async def {{ test_function_name | dotunderscore }}(service_bus_emulator):
         serialized_data = {}
     
     # Create CloudEvent with required attributes
+    {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
     attributes = {
         "specversion": "1.0",
-        "type": "{{ messageid }}",
+        "type": "{{ ce_type_value }}",
         "source": "test",
         {%- for attrname, attribute in message.envelopemetadata.items() if attribute.required and attribute.value is not defined %}
         "{{ attrname }}": {{ "'test'" if not attrname == 'time' else 'datetime.datetime.now().isoformat()' }},

--- a/xrcg/templates/py/sbconsumer/{testdir}test_dispatcher.py.jinja
+++ b/xrcg/templates/py/sbconsumer/{testdir}test_dispatcher.py.jinja
@@ -204,7 +204,8 @@ async def {{ test_function_name | dotunderscore }}(service_bus_emulator):
                         body=msg_body,
                         content_type="application/json",
                         application_properties={
-                            "cloudEvents:type": "{{ messageid }}",
+                            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+                            "cloudEvents:type": "{{ ce_type_value }}",
                             "cloudEvents:source": "test",
                             "cloudEvents:id": f"test-id-{i}",
                             "cloudEvents:specversion": "1.0"

--- a/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/src/{mainprojectdir!dotunderscore!lower}producer.py.jinja
@@ -76,13 +76,13 @@ class {{ class_name }}:
         _{{ attrname }}: str, {{ '' }}
     {%- endfor -%}
     {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != "time" -%}
-        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}_{{ placeholder | snake }} : str, {% endfor -%}
+        {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}_{{ placeholder | snake }} : str, {% endfor -%}
     {%- endfor -%}
     {%- set time_placeholder_params = [] -%}
     {%- if 'time' in message.envelopemetadata and message.envelopemetadata['time'].type == "uritemplate" and message.envelopemetadata['time'].value -%}
         {%- for placeholder in message.envelopemetadata['time'].value | regex_search('\\{([A-Za-z0-9_]+)\\}') -%}
             {%- set placeholder_name = placeholder | snake -%}
-            {%- if placeholder_name not in time_placeholder_params -%}
+            {%- if placeholder_name not in time_placeholder_params and placeholder_name != 'time' -%}
                 {%- set _ = time_placeholder_params.append(placeholder_name) -%}
             {%- endif -%}
         {%- endfor -%}

--- a/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
@@ -172,7 +172,7 @@ async def {{ test_function_name | dotunderscore }}(service_bus_emulator):
             _{{ attrname }}=f"test_{{ attrname }}_{i}",
             {%- endfor %}
             {%- for attrname, attribute in message.envelopemetadata.items() if attribute.type == "uritemplate" and attrname != 'time' %}
-            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+            {%- for placeholder in attribute.value | regex_search('\\{([A-Za-z0-9_]+)\\}') if (placeholder | snake) != 'time' %}
             _{{ placeholder | snake }}=f"test_{{ placeholder }}_{i}",
             {%- endfor %}
             {%- endfor %}

--- a/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
+++ b/xrcg/templates/py/sbproducer/{testdir}test_producer.py.jinja
@@ -144,6 +144,7 @@ async def service_bus_emulator():
 {%- for messageid, message in messagegroup.messages.items() if (message | exists("envelope","CloudEvents/1.0")) %}
 {%- set messagename = messageid | pascal | strip_dots | strip_namespace %}
 {%- set message_snake = messageid | dotunderscore | snake %}
+{%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
 {%- set test_function_name = "test_" + groupname | lower | replace(" ", "_") + "_" + messagename | lower | replace(" ", "_") %}
 {%- set type_name = util.DeclareDataType( data_project_name, root, message ) %}
 
@@ -198,19 +199,19 @@ async def {{ test_function_name | dotunderscore }}(service_bus_emulator):
                     body_data = json.loads(str(msg))
                     if "type" in body_data:
                         # Structured mode
-                        assert body_data["type"] == "{{ messageid }}"
+                        assert body_data["type"] == "{{ ce_type_value }}"
                     else:
                         # Binary mode - check application_properties
                         app_props = msg.application_properties or {}
                         assert "cloudEvents:type" in app_props or "cloudEvents_type" in app_props, f"CloudEvents type not found in application_properties: {app_props}"
                         ce_type = app_props.get("cloudEvents:type") or app_props.get("cloudEvents_type")
-                        assert ce_type == "{{ messageid }}"
+                        assert ce_type == "{{ ce_type_value }}"
                 except (json.JSONDecodeError, UnicodeDecodeError):
                     # Binary mode - check application_properties
                     app_props = msg.application_properties or {}
                     assert "cloudEvents:type" in app_props or "cloudEvents_type" in app_props, f"CloudEvents type not found in application_properties: {app_props}"
                     ce_type = app_props.get("cloudEvents:type") or app_props.get("cloudEvents_type")
-                    assert ce_type == "{{ messageid }}"
+                    assert ce_type == "{{ ce_type_value }}"
                 
                 await receiver.complete_message(msg)
 

--- a/xrcg/templates/ts/amqpconsumer/src/dispatcher.ts.jinja
+++ b/xrcg/templates/ts/amqpconsumer/src/dispatcher.ts.jinja
@@ -261,7 +261,8 @@ export class {{ class_name }} {
             {%- set isCloudEvent = cloudEvents.isCloudEvent(message) %}
             {%- set message_body_type = util.body_type(data_project_name, root, message) %}
             {%- if isCloudEvent %}
-            case '{{ messageid }}':
+            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+            case '{{ ce_type_value }}':
                 if (this.{{ messagename }}Handler) {
                     const data = cloudEvent.data as unknown as {{ message_body_type }};
                     await this.{{ messagename }}Handler(cloudEvent, data, context);

--- a/xrcg/templates/ts/sbconsumer/src/dispatcher.ts.jinja
+++ b/xrcg/templates/ts/sbconsumer/src/dispatcher.ts.jinja
@@ -123,7 +123,8 @@ export class {{ class_name }} {
             {%- set messagename = messageid | pascal | strip_namespace %}
             {%- set isCloudEvent = cloudEvents.isCloudEvent(message) %}
             {%- set message_body_type = util.body_type(data_project_name, root, message) %}
-            case '{{ messageid }}':
+            {%- set ce_type_value = message.envelopemetadata["type"]["value"] if ("type" in message.envelopemetadata and "value" in message.envelopemetadata["type"]) else messageid %}
+            case '{{ ce_type_value }}':
                 if (this.{{ messagename }}Handler) {
                     const data = cloudEvent.data as unknown as {{ message_body_type }};
                     await this.{{ messagename }}Handler(message, {% if isCloudEvent %}cloudEvent, {% endif %}data);


### PR DESCRIPTION
Fixes four open codegen issues. Each fix is surgical and ships with a targeted regression test in `test/py/test_python.py`.

## Closes
- Closes #467
- Closes #466
- Closes #430
- Closes #432

## #467 — producer test asserts map key instead of resolved CloudEvents `type`
Generated producer integration tests asserted `type` against the `messages` map key, which fails when a manifest disambiguates per-transport variants with a key infix (e.g. `...amqp.Info`). They now assert the resolved `envelopemetadata.type.value` (the value the producer actually emits, honoring `basemessageuri` inheritance), falling back to the map key only when no type value is declared.
Templates: `py/{amqp,sb,eh,kafka}producer` test templates + `cs/amqpproducer` test.

## #466 — duplicate `_time` argument → `SyntaxError` (AMQP Python producer)
A protocol-option (or envelope) uritemplate placeholder literally named `time` was emitted as `_time`, colliding with the reserved CloudEvents `_time` override the generator always injects, making the module unimportable. The placeholder now binds to the reserved `_time` (the `.format(time=_time)` body call is unchanged). Guards cover the arg-name collection, both send/batch signatures, and the batch fan-out call.

## #430 — resilient Kafka `flush()` helper (feature)
Generated `*EventProducer` classes now expose `flush(timeout=30, retries=3, backoff_factor=2.0)` with exponential backoff that raises `RuntimeError` if messages remain unsent — eliminating hand-rolled flush-with-retry boilerplate around idle-timeout brokers (Azure Event Hubs, Confluent Cloud).

## #432 — MQTT v5 OAUTH2-JWT enhanced auth (feature)
The generated MQTT client `connect()` gains an optional `token` (plus `authentication_method`/`properties`) that presents an Entra/OAuth2 JWT via MQTT v5 Enhanced Authentication CONNECT properties (`AuthenticationMethod=OAUTH2-JWT` + `AuthenticationData`), as Azure Event Grid Namespaces require. The default token-less path is unchanged, preserving MQTT v3.1.1 compatibility.

## Validation
21 targeted tests pass (5 new regressions + neighbors): protocol-option/time placeholder, kafka flush helper, mqtt enhanced-auth (and default-path guard), resolved-type assertion, plus all existing mqtt connect, amqp protocoloptions/time, and transport-render tests.