### PR TITLE
chore(deps): roll-up of 18 non-major Dependabot bumps

### DIFF
--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -5,12 +5,12 @@
     <ItemGroup>
       <PackageReference Include="AMQPNetLite" Version="2.5.2" />
       <PackageReference Include="Apache.Avro" Version="1.12.1" />
-      <PackageReference Include="Azure.Core" Version="1.57.0" />
+      <PackageReference Include="Azure.Core" Version="1.60.0" />
       <PackageReference Include="Azure.Core.Amqp" Version="1.3.1" />
       <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
       <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
       <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
@@ -32,7 +32,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.1.0.1559" />
-      <PackageReference Include="System.Memory.Data" Version="10.0.8" />
+      <PackageReference Include="System.Memory.Data" Version="10.0.9" />
       <PackageReference Include="System.Text.Json" Version="10.0.8" />
       <PackageReference Include="Testcontainers" Version="4.12.0" />
       <PackageReference Include="Testcontainers.ActiveMq" Version="4.12.0" />

--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -12,14 +12,14 @@
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
-      <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Avro" Version="2.8.0" />
-      <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
       <PackageReference Include="Confluent.Kafka" Version="2.13.0" />
-      <PackageReference Include="Google.Protobuf" Version="3.35.0" />
+      <PackageReference Include="Google.Protobuf" Version="3.35.1" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />

--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -24,7 +24,7 @@
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
       <PackageReference Include="Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents" Version="1.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />

--- a/xrcg/dependencies/cs/net100/dependencies.csproj
+++ b/xrcg/dependencies/cs/net100/dependencies.csproj
@@ -25,9 +25,9 @@
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
       <PackageReference Include="Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents" Version="1.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />

--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -12,10 +12,10 @@
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
-      <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.8.0" />
-      <PackageReference Include="CloudNative.CloudEvents.Avro" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents.Avro" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />
       <PackageReference Include="Confluent.Kafka" Version="2.14.0" />

--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -5,12 +5,12 @@
     <ItemGroup>
       <PackageReference Include="AMQPNetLite" Version="2.5.1" />
       <PackageReference Include="Apache.Avro" Version="1.12.1" />
-      <PackageReference Include="Azure.Core" Version="1.57.0" />
+      <PackageReference Include="Azure.Core" Version="1.60.0" />
       <PackageReference Include="Azure.Core.Amqp" Version="1.3.1" />
       <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
       <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
-      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+      <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
       <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
@@ -31,10 +31,10 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-      <PackageReference Include="System.Memory.Data" Version="10.0.8" />
-      <PackageReference Include="System.Text.Json" Version="10.0.8" />
+      <PackageReference Include="System.Memory.Data" Version="10.0.9" />
+      <PackageReference Include="System.Text.Json" Version="10.0.9" />
       <PackageReference Include="Testcontainers" Version="4.13.0" />
-      <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.ActiveMq" Version="4.13.0" />
       <PackageReference Include="Testcontainers.Azurite" Version="4.13.0" />
       <PackageReference Include="Testcontainers.Kafka" Version="4.12.0" />
       <PackageReference Include="xunit" Version="2.9.3" />

--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -33,9 +33,9 @@
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
       <PackageReference Include="System.Memory.Data" Version="10.0.8" />
       <PackageReference Include="System.Text.Json" Version="10.0.8" />
-      <PackageReference Include="Testcontainers" Version="4.12.0" />
+      <PackageReference Include="Testcontainers" Version="4.13.0" />
       <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
-      <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />
+      <PackageReference Include="Testcontainers.Azurite" Version="4.13.0" />
       <PackageReference Include="Testcontainers.Kafka" Version="4.12.0" />
       <PackageReference Include="xunit" Version="2.9.3" />
       <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/xrcg/dependencies/cs/net80/dependencies.csproj
+++ b/xrcg/dependencies/cs/net80/dependencies.csproj
@@ -27,7 +27,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />

--- a/xrcg/dependencies/cs/net90/dependencies.csproj
+++ b/xrcg/dependencies/cs/net90/dependencies.csproj
@@ -5,16 +5,16 @@
     <ItemGroup>
       <PackageReference Include="AMQPNetLite" Version="2.5.3" />
       <PackageReference Include="Apache.Avro" Version="1.12.1" />
-      <PackageReference Include="Azure.Core" Version="1.51.0" />
+      <PackageReference Include="Azure.Core" Version="1.55.0" />
       <PackageReference Include="Azure.Core.Amqp" Version="1.3.1" />
       <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
       <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-      <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+      <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
       <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.9.0" />
-      <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.Avro" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.8.0" />

--- a/xrcg/dependencies/cs/net90/dependencies.csproj
+++ b/xrcg/dependencies/cs/net90/dependencies.csproj
@@ -12,8 +12,8 @@
       <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.12.2" />
       <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-      <PackageReference Include="CloudNative.CloudEvents" Version="2.8.0" />
-      <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.8.0" />
+      <PackageReference Include="CloudNative.CloudEvents" Version="2.9.0" />
+      <PackageReference Include="CloudNative.CloudEvents.Amqp" Version="2.9.0" />
       <PackageReference Include="CloudNative.CloudEvents.AspNetCore" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Avro" Version="2.8.0" />
       <PackageReference Include="CloudNative.CloudEvents.Protobuf" Version="2.8.0" />

--- a/xrcg/dependencies/cs/net90/dependencies.csproj
+++ b/xrcg/dependencies/cs/net90/dependencies.csproj
@@ -24,15 +24,15 @@
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
       <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
       <PackageReference Include="Microsoft.Azure.Messaging.EventGrid.CloudNativeCloudEvents" Version="1.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
       <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.6" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
       <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
       <PackageReference Include="System.Memory.Data" Version="10.0.8" />
-      <PackageReference Include="System.Text.Json" Version="10.0.8" />
+      <PackageReference Include="System.Text.Json" Version="10.0.9" />
       <PackageReference Include="Testcontainers" Version="4.12.0" />
       <PackageReference Include="Testcontainers.ActiveMq" Version="4.11.0" />
       <PackageReference Include="Testcontainers.Azurite" Version="4.11.0" />

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-json-jackson</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventhubs</artifactId>
-            <version>5.21.3</version>
+            <version>5.21.4</version>
         </dependency>
 
         <!-- Azure Service Bus -->

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.0</version>
+            <version>6.1.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
-            <version>1.21.4</version>
+            <version>1.21.6</version>
         </dependency>
 
         <!-- CloudEvents -->


### PR DESCRIPTION
Roll-up of 18 non-major Dependabot dependency bumps into a single PR to avoid O(n^2) CI churn under strict branch protection (each individual merge re-stales all other PRs).

## Included bumps

**Maven (`xrcg/dependencies/java/jdk21/pom.xml`)** — closes #493 #494 #495 #497
- azure-messaging-eventhubs 5.21.3 -> 5.21.4
- azure-messaging-eventhubs-checkpointstore-blob 1.21.4 -> 1.21.6
- cloudevents-json-jackson 4.1.0 -> 4.1.1
- junit-jupiter 6.1.0 -> 6.1.1

**NuGet net80/net90/net100 (`dependencies.csproj`)** — closes #451 #454 #459 #461 #499 #510 #511 #512 #514 #515 #518 #521 #522 #523
- Azure.Core, Azure.Messaging.ServiceBus, Azure.Storage.Blobs, System.Memory.Data, System.Text.Json
- CloudNative.CloudEvents (+ .Amqp/.AspNetCore/.Avro/.Protobuf)
- Microsoft.Extensions.Logging (+ .Console/.Debug), Microsoft.Extensions.DependencyModel
- Microsoft.NET.Test.Sdk, Testcontainers (+ .ActiveMq/.Azurite), Google.Protobuf

Overlapping grouped updates were resolved by taking the **highest requested version** per package.

Only the 4 dependency manifests change. Full CI (test-csharp net80/90/100, test-java) gates the merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
