### PR TITLE
chore(deps): roll-up of low-risk major bumps (checkout 7, cache 6, @types/node 26)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         python: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -119,7 +119,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Download all wheel artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-proton-windows-wheels.yml
+++ b/.github/workflows/build-proton-windows-wheels.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache vcpkg
         id: vcpkg-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             C:/vcpkg/installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -38,7 +38,7 @@ jobs:
     
     steps:
     - name: Checkout gh-pages branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: gh-pages
         fetch-depth: 0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -31,7 +31,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Full history for version detection
         ref: ${{ github.ref }}  # Explicitly checkout the ref (tag or branch)

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -30,7 +30,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Full history for version detection
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up .NET SDK
       uses: actions/setup-dotnet@v5.4.0
       with:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
@@ -126,7 +126,7 @@ jobs:
       AMQP_BROKER: rabbitmq
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
@@ -142,7 +142,7 @@ jobs:
       with:
         python-version: 3.11
     - name: Get CloudNative.CloudEvents.Endpoint package code (java)
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: clemensv/io.cloudevents.experimental.endpoints
         ref: main
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Set up Python
       uses: actions/setup-python@v6
       with:

--- a/xrcg/dependencies/typescript/node22/package.json
+++ b/xrcg/dependencies/typescript/node22/package.json
@@ -19,7 +19,7 @@
     "@stylistic/eslint-plugin": "^5.6.1",
     "@testcontainers/kafka": "^12.0.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.0.10",
+    "@types/node": "^26.1.1",
     "@types/uuid": "^11.0.0",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",


### PR DESCRIPTION
Roll-up of the three low-risk major Dependabot bumps (validated together to avoid strict-mode serial CI churn):

- **actions/checkout 6 -> 7** (closes #474) - CI workflows only
- **actions/cache 5 -> 6** (closes #492) - CI workflow only
- **@types/node 25 -> 26** (closes #519) - TypeScript dev types

Only CI workflow files and one package.json change. Full CI gates the merge. The two higher-risk majors (kafka-clients 4.x #490, typescript 7 #520) are handled separately pending review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
