### PR TITLE
chore(deps): major bumps roll-up - kafka-clients 4.3.1, typescript 7.0.2

### DIFF
--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>3.9.0</version>
+            <version>4.3.1</version>
         </dependency>
 
         <!-- AMQP - Apache Qpid ProtonJ2 -->

--- a/xrcg/dependencies/typescript/node22/package.json
+++ b/xrcg/dependencies/typescript/node22/package.json
@@ -29,6 +29,6 @@
     "testcontainers": "^12.0.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.0",
-    "typescript": "^6.0.2"
+    "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
Roll-up of the two reviewed major dependency bumps, both independently CI-validated green (all checks incl. test-other) before roll-up:

- #490 org.apache.kafka:kafka-clients 3.9.x -> 4.3.1 (Java Kafka producer/consumer templates)
- #520 typescript 6.x -> 7.0.2 (TypeScript template compiler)

Combined here for a single CI run + squash merge under strict branch protection.

Closes #490
Closes #520
