### PR TITLE
chore(deps): patch bumps roll-up - junit-jupiter 6.1.2, eventhubs-checkpointstore-blob 1.21.7

### DIFF
--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -199,7 +199,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/xrcg/dependencies/java/jdk21/pom.xml
+++ b/xrcg/dependencies/java/jdk21/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventhubs-checkpointstore-blob</artifactId>
-            <version>1.21.6</version>
+            <version>1.21.7</version>
         </dependency>
 
         <!-- CloudEvents -->


### PR DESCRIPTION
Roll-up of two trivial Java patch bumps that appeared after the major roll-up (#526):

- #495 org.junit.jupiter:junit-jupiter 6.1.1 -> 6.1.2
- #497 com.azure:azure-messaging-eventhubs-checkpointstore-blob 1.21.6 -> 1.21.7

Combined for a single CI run + squash merge under strict branch protection.

Closes #495
Closes #497
