### PR TITLE
ci: add workflow_dispatch to Python Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
     tags:
       - 'v*'
+  workflow_dispatch:
     
 jobs:
   # Core tests - validation, xreg, codegen (no Docker, fast)


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to `.github/workflows/test.yml` so the full test matrix can be run manually on demand.

Motivation: Dependabot auto-merges use the `GITHUB_TOKEN`, and pushes made with that token do not trigger push-triggered workflows. This left the last two patch-bump merge commits (#495, #497) without a main-HEAD CI run. A manual trigger closes that gap for future cases. This PR's own CI run also validates the current main tree.