### PR TITLE
Fix Python MQTT client disconnect() dropping queued QoS-1 publishes (#486)

### DIFF
--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -7,6 +7,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+import time
 from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
@@ -282,6 +283,7 @@ class {{ class_name }}(_ClientBase):
         self._topic_patterns = {k: _build_topic_regex(v) for k, v in self._topic_mappings.items()}
         self._connect_waiter: Optional[asyncio.Future[None]] = None
         self._connected = False
+        self._inflight: List[mqtt.MQTTMessageInfo] = []
         
         # Message handler callbacks (Dispatcher pattern)
         {% for messageid, message in messagegroup.messages.items() if (message | exists("envelope","CloudEvents/1.0")) -%}
@@ -558,11 +560,59 @@ class {{ class_name }}(_ClientBase):
                 await asyncio.to_thread(self.client.loop_stop)
             raise
     
+    def _track_inflight(self, info: Optional[mqtt.MQTTMessageInfo]) -> None:
+        """Record an outstanding publish so ``disconnect()`` can flush it.
+
+        Already-delivered handles are pruned first so the list stays bounded to
+        genuinely in-flight messages in long-running producers.
+        """
+        if info is None:
+            return
+        self._inflight = [i for i in self._inflight if not self._is_published(i)]
+        self._inflight.append(info)
+
+    @staticmethod
+    def _is_published(info: mqtt.MQTTMessageInfo) -> bool:
+        """Best-effort check whether a publish handle has been delivered."""
+        try:
+            return bool(info.is_published())
+        except (ValueError, RuntimeError):
+            # Treat unknown/torn-down handles as done so they are pruned.
+            return True
+
+    async def _flush_inflight(self, timeout: float = 10.0) -> None:
+        """Bound-wait for outstanding QoS>0 publishes to be acknowledged.
+
+        The blocking paho wait runs off the event-loop thread so the asyncio
+        loop is never stalled.
+        """
+        if not self._inflight:
+            return
+        deadline = time.monotonic() + timeout
+        for info in self._inflight:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                await asyncio.to_thread(info.wait_for_publish, remaining)
+            except (ValueError, RuntimeError):
+                # ValueError: nothing to wait for (already delivered/removed).
+                # RuntimeError: network loop no longer running.
+                pass
+        self._inflight.clear()
+
     async def disconnect(self):
-        """Disconnect from MQTT broker."""
+        """Disconnect from the MQTT broker after flushing queued publishes.
+
+        QoS>0 PUBLISH packets may still sit in paho's out-queue when a
+        short-lived ('--once') producer disconnects. Stopping the network loop
+        first would silently drop them, so we bound-wait for in-flight delivery
+        (PUBACK) before sending DISCONNECT and stopping the loop off-thread.
+        """
         self._connected = False
-        self.client.loop_stop()
+        await self._flush_inflight()
         self.client.disconnect()
+        await asyncio.to_thread(self.client.loop_stop)
 
     # Producer methods
     {% for messageid, message in messagegroup.messages.items() if (message | exists("envelope","CloudEvents/1.0")) -%}
@@ -746,7 +796,7 @@ class {{ class_name }}(_ClientBase):
         elif isinstance(payload, str):
             payload = payload.encode('utf-8')
 
-        self.client.publish(target_topic, payload, **publish_kwargs)
+        self._track_inflight(self.client.publish(target_topic, payload, **publish_kwargs))
 
     {% endfor %}
     {% for messageid, message in messagegroup.messages.items() if not (message | exists("envelope","CloudEvents/1.0")) -%}
@@ -847,7 +897,7 @@ class {{ class_name }}(_ClientBase):
         _effective_qos = {{ default_qos }} if qos is None else qos
         _effective_retain = {{ default_retain }} if retain is None else retain
 
-        self.client.publish(target_topic, payload, qos=_effective_qos, retain=_effective_retain)
+        self._track_inflight(self.client.publish(target_topic, payload, qos=_effective_qos, retain=_effective_retain))
 
     {% endfor %}
 {% endfor %}

--- a/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
+++ b/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
@@ -343,4 +343,59 @@ async def test_{{groupName}}_{{messagename.split('.')[-1]}}_plain_roundtrip_py(m
     await publisher_client.disconnect()
 
 {% endfor %}
+
+@pytest.mark.asyncio
+async def test_{{groupName}}_disconnect_flushes_inflight_qos1_py():
+    """Regression for issue #486.
+
+    A short-lived ('--once') producer that publishes a QoS-1 message and then
+    immediately disconnects must not drop the last-queued message. ``disconnect()``
+    must wait for in-flight delivery (PUBACK) BEFORE stopping paho's network loop.
+
+    Uses a fake paho client so the ordering is asserted deterministically without
+    depending on broker/network timing.
+    """
+    calls = []
+
+    class _FakeInfo:
+        def __init__(self):
+            self._published = False
+
+        def wait_for_publish(self, timeout=None):
+            calls.append("wait_for_publish")
+            self._published = True
+
+        def is_published(self):
+            return self._published
+
+    class _FakeClient:
+        def __init__(self):
+            self.on_message = None
+            self.on_connect = None
+            self.on_disconnect = None
+
+        def publish(self, *args, **kwargs):
+            calls.append("publish")
+            return _FakeInfo()
+
+        def disconnect(self, *args, **kwargs):
+            calls.append("disconnect")
+
+        def loop_stop(self, *args, **kwargs):
+            calls.append("loop_stop")
+
+    loop = asyncio.get_running_loop()
+    client = {{ class_name }}(_FakeClient(), loop=loop)
+
+    # Simulate a QoS-1 publish still in flight, then disconnect immediately.
+    client._track_inflight(client.client.publish("test/topic", b"{}", qos=1))
+    await client.disconnect()
+
+    assert "wait_for_publish" in calls, \
+        "disconnect() must flush queued QoS-1 publishes before stopping the loop"
+    assert calls.index("wait_for_publish") < calls.index("loop_stop"), \
+        "disconnect() must wait for in-flight delivery BEFORE loop_stop()"
+    assert calls.index("disconnect") < calls.index("loop_stop"), \
+        "disconnect() must send DISCONNECT before stopping the loop"
+
 {% endfor %}


### PR DESCRIPTION
## Summary

Fixes #486 — the generated Python async MQTT client silently dropped queued **QoS-1** publishes on `disconnect()`.

### Root cause
`disconnect()` called `loop_stop()` **before** `disconnect()`, joining paho's network thread while QoS-1 PUBLISH packets were still sitting in the out-queue. In short-lived (`--once`) producers the last-queued message was silently lost. Compounding it, `publish_*` discarded the returned `MQTTMessageInfo`, so delivery was never awaited.

### Fix
- Track each publish's `MQTTMessageInfo` in `self._inflight` (already-delivered handles are pruned on each track to stay bounded in long-running producers).
- In `disconnect()`, bound-wait for PUBACK via `wait_for_publish` — off the event loop with `asyncio.to_thread` — **before** sending DISCONNECT and stopping the loop off-thread.

### Tests
Adds a **deterministic, broker-free** regression test (fake paho client) that asserts `disconnect()` flushes in-flight publishes before `loop_stop()`. Verified locally:
- **Passes** with the fix.
- **Fails** against the old teardown (`calls == ['publish', 'loop_stop', 'disconnect']` — no flush).

The test is emitted once per message group and runs as part of every generated mqttclient `make test` (exercised by the existing `test_mqttclient_*_py` harness cases). It needs no Docker/broker, so it adds negligible CI time.

Closes #486

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
