### PR TITLE
Fix generated MQTT client shared-paho-client callback stealing (#485)

### DIFF
--- a/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
+++ b/xrcg/templates/py/mqttclient/src/{mainprojectdir!dotunderscore!lower}client.py.jinja
@@ -7,6 +7,7 @@ import re
 import typing
 from typing import Callable, Awaitable, Optional, Dict, List
 import asyncio
+import weakref
 from datetime import datetime, timezone
 import paho.mqtt.client as mqtt
 try:
@@ -130,6 +131,69 @@ def _mqtt5_properties_to_ce_headers(properties) -> Dict[str, str]:
             continue
         headers["ce-" + str(k).lower()] = str(v)
     return headers
+
+
+class _MqttCallbackMultiplexer:
+    """Fan paho ``on_connect``/``on_disconnect``/``on_message`` callbacks out to
+    every generated client instance that shares a single paho client.
+
+    Multiple generated ``*MqttClient`` classes are designed to share one
+    ``paho.mqtt.client.Client`` (one connection per multi-messagegroup source).
+    Paho stores only ONE callback per event, so without multiplexing the
+    last-instantiated client would silently steal ``on_connect``/``on_message``
+    from every earlier client -- making their ``connect()`` hang forever because
+    the CONNACK resolves the wrong instance's waiter. See issue #485.
+
+    Instances are held weakly so the multiplexer never keeps a dropped client
+    alive; dead references are pruned on registration and on every dispatch.
+    """
+
+    _ATTR = "_xrcg_callback_multiplexer"
+
+    def __init__(self) -> None:
+        self._instances: List["weakref.ReferenceType"] = []
+
+    @classmethod
+    def attach(cls, client: "mqtt.Client", instance: object) -> None:
+        """Register ``instance`` for shared callbacks on ``client``.
+
+        The first instance to attach installs the multiplexer as the client's
+        callback and stores it on the client object; later instances that share
+        the same client reuse it instead of overwriting the callbacks.
+        """
+        mux = getattr(client, cls._ATTR, None)
+        if not isinstance(mux, _MqttCallbackMultiplexer):
+            mux = cls()
+            setattr(client, cls._ATTR, mux)
+            client.on_connect = mux._dispatch_connect
+            client.on_disconnect = mux._dispatch_disconnect
+            client.on_message = mux._dispatch_message
+        mux._register(instance)
+
+    def _register(self, instance: object) -> None:
+        self._instances = [ref for ref in self._instances if ref() is not None]
+        if all(ref() is not instance for ref in self._instances):
+            self._instances.append(weakref.ref(instance))
+
+    def _live(self) -> List[object]:
+        live: List[object] = []
+        for ref in list(self._instances):
+            inst = ref()
+            if inst is not None:
+                live.append(inst)
+        return live
+
+    def _dispatch_connect(self, client, userdata, flags, reason_code=0, properties=None) -> None:
+        for inst in self._live():
+            inst._on_connect(client, userdata, flags, reason_code, properties)
+
+    def _dispatch_disconnect(self, client, userdata, *args) -> None:
+        for inst in self._live():
+            inst._on_disconnect(client, userdata, *args)
+
+    def _dispatch_message(self, client, userdata, message) -> None:
+        for inst in self._live():
+            inst._on_message(client, userdata, message)
 
 
 class _ClientBase:
@@ -295,10 +359,10 @@ class {{ class_name }}(_ClientBase):
         self.{{messagename.split('.')[-1]}}_async: Optional[Callable[[mqtt.MQTTMessage, {{type_name}}, Dict[str, str]], Awaitable[None]]] = None
         {% endfor %}
         
-        # Attach message callback
-        self.client.on_message = self._on_message
-        self.client.on_connect = self._on_connect
-        self.client.on_disconnect = self._on_disconnect
+        # Multiplex paho callbacks so several generated clients can safely share
+        # one paho client (issue #485) instead of overwriting each other's
+        # on_connect/on_disconnect/on_message registrations.
+        _MqttCallbackMultiplexer.attach(self.client, self)
 
     @staticmethod
     def _mqtt_reason_code_value(reason_code) -> Optional[int]:

--- a/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
+++ b/xrcg/templates/py/mqttclient/{testdir}test_client.py.jinja
@@ -77,6 +77,57 @@ async def mosquitto_broker():
 {%- set groupname = messagegroupid | pascal %}
 {%- set class_name = ( groupname | strip_dots )+"MqttClient" %}
 
+@pytest.mark.asyncio
+async def test_{{groupName}}_shared_paho_client_connect_multiplexes_py():
+    """Regression for issue #485.
+
+    Several generated clients are meant to share one paho client (one connection
+    per multi-messagegroup source). Paho stores only one callback per event, so a
+    later-instantiated client used to overwrite the shared ``on_connect`` and make
+    an earlier client's ``connect()`` hang forever. A callback multiplexer must fan
+    the CONNACK out to every instance so ``connect()`` resolves regardless of order.
+
+    Deterministic (fake paho client, no broker): the second instance is created
+    AFTER the first, then ``connect()`` on the FIRST instance must still complete.
+    """
+    class _FakeClient:
+        def __init__(self):
+            self.on_connect = None
+            self.on_disconnect = None
+            self.on_message = None
+
+        def connect(self, *args, **kwargs):
+            pass
+
+        def loop_start(self):
+            # Simulate the broker's CONNACK arriving on the network thread.
+            if self.on_connect is not None:
+                self.on_connect(self, None, {}, 0, None)
+
+        def loop_stop(self, *args, **kwargs):
+            pass
+
+        def disconnect(self, *args, **kwargs):
+            pass
+
+    loop = asyncio.get_running_loop()
+    shared = _FakeClient()
+    first = {{ class_name }}(shared, loop=loop)
+    second = {{ class_name }}(shared, loop=loop)  # would steal first's on_connect pre-fix
+
+    mux = getattr(shared, "_xrcg_callback_multiplexer", None)
+    assert mux is not None and len(mux._live()) == 2, \
+        "both clients sharing one paho client must register on the callback multiplexer (#485)"
+
+    try:
+        await first.connect("broker", 1883, keepalive=5)
+    except (asyncio.TimeoutError, TimeoutError):
+        pytest.fail(
+            "connect() on a shared-client instance timed out - a later client "
+            "overwrote the shared on_connect callback (issue #485)"
+        )
+    assert first._connected is True
+
 {% for messageid, message in messagegroup.messages.items() if (message | exists("envelope","CloudEvents/1.0")) -%}
 {%- set messagename = messageid | dotunderscore | snake %}
 {%- set type_name = util.DeclareDataType( data_project_name, root, message ) %}


### PR DESCRIPTION
## Summary

Fixes #485 — when several generated `*MqttClient` classes share one `paho.mqtt.client.Client` (the intended pattern for multi-messagegroup sources), each `__init__` overwrote paho's single `on_connect`/`on_disconnect`/`on_message` slot. Only the **last-instantiated** client's callbacks stayed live, so `connect()` on any earlier client hung forever — the CONNACK resolved the wrong instance's waiter. This broke ~25 multi-group feeders in `clemensv/real-time-sources`.

### Fix
A module-level `_MqttCallbackMultiplexer` is attached to the shared paho client:
- The **first** instance to attach wires paho's callbacks to the multiplexer and stores it on the client object; later instances sharing that client **register** with it instead of overwriting.
- Instances are held **weakly** (pruned on register and on every dispatch), so a dropped client is never kept alive.
- The multiplexer **fans** `on_connect`/`on_disconnect`/`on_message` out to all live instances — each resolves its own connect waiter and dispatches only its own topics.

Callback signatures are preserved exactly (paho `CallbackAPIVersion.VERSION2`), so single-client behavior is unchanged.

### Tests
Adds a **deterministic, broker-free** regression test (fake paho client), emitted once per message group: a second client is instantiated **after** the first, then `connect()` on the first must still complete. Verified locally:
- ✅ **passes** with the fix
- ❌ **fails** without it (multiplexer absent; `connect()` would hang)

Also ran the **full broker-backed generated suite** (`test_mqttclient_fabrikam_motorsports_py`, testcontainers Mosquitto, 3m41s) — green, confirming the normal single-client connect/subscribe/publish/receive flow is unaffected.

Closes #485

---
Note: independent of #529 (#486 fix); both touch the mqttclient template but in different regions. The only overlap is one import line (`import weakref` vs `import time`) — trivially both-kept on whichever merges second.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
