### PR TITLE
Make Python to_byte_array JSON guard injection idempotent (#501)

### DIFF
--- a/test/codegen/test_python_postprocessor.py
+++ b/test/codegen/test_python_postprocessor.py
@@ -1,0 +1,82 @@
+"""Regression tests for the Avrotize Python post-processing fixes.
+
+Covers issue #501: ``apply_python_avrotize_fixes`` injected a ``str -> bytes``
+guard into the ``application/json`` branch of ``to_byte_array`` non-idempotently,
+so regenerating over an existing output appended a duplicate guard on every run.
+"""
+
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+sys.path.append(project_root)
+
+from xrcg.generator.python_codegen_postprocessor import (  # noqa: E402
+    _JSON_TO_BYTES_PATTERN,
+    _encode_json_result,
+    apply_python_avrotize_fixes,
+)
+
+# Raw Avrotize output for the ``to_byte_array`` JSON branch, i.e. BEFORE the
+# post-processor adds the ``str -> bytes`` guard.
+_RAW_DATACLASS = (
+    "import json\n"
+    "\n"
+    "\n"
+    "class Sample:\n"
+    "    def to_byte_array(self, content_type: str) -> bytes:\n"
+    "        base_content_type = content_type.split('+')[0]\n"
+    "        result = None\n"
+    "        if base_content_type == 'application/json':\n"
+    "            #pylint: disable=no-member\n"
+    "            result = self.to_json()\n"
+    "            #pylint: enable=no-member\n"
+    "        return result\n"
+)
+
+_GUARD = "if isinstance(result, str):"
+_ENCODE = "result = result.encode('utf-8')"
+
+
+def _guard_count(text: str) -> int:
+    return text.count(_GUARD)
+
+
+def test_pattern_injects_guard_once():
+    """First pass over raw output injects exactly one guard."""
+    once = _JSON_TO_BYTES_PATTERN.sub(_encode_json_result, _RAW_DATACLASS)
+    assert _guard_count(once) == 1
+    assert once.count(_ENCODE) == 1
+
+
+def test_pattern_is_idempotent():
+    """A second pass must not append a duplicate guard (issue #501)."""
+    once = _JSON_TO_BYTES_PATTERN.sub(_encode_json_result, _RAW_DATACLASS)
+    twice = _JSON_TO_BYTES_PATTERN.sub(_encode_json_result, once)
+    assert twice == once
+    assert _guard_count(twice) == 1
+
+
+def test_pattern_idempotent_without_pylint_comments():
+    """Guard injection stays idempotent when the pylint markers are absent."""
+    raw = _RAW_DATACLASS.replace("            #pylint: disable=no-member\n", "")
+    raw = raw.replace("            #pylint: enable=no-member\n", "")
+    once = _JSON_TO_BYTES_PATTERN.sub(_encode_json_result, raw)
+    twice = _JSON_TO_BYTES_PATTERN.sub(_encode_json_result, once)
+    assert _guard_count(once) == 1
+    assert twice == once
+
+
+def test_apply_fixes_idempotent_on_disk(tmp_path):
+    """Regenerating over existing output is a no-op (the reported scenario)."""
+    py_file = tmp_path / "sample.py"
+    py_file.write_text(_RAW_DATACLASS, encoding="utf-8")
+
+    apply_python_avrotize_fixes(str(tmp_path))
+    first = py_file.read_text(encoding="utf-8")
+    assert _guard_count(first) == 1
+
+    apply_python_avrotize_fixes(str(tmp_path))
+    second = py_file.read_text(encoding="utf-8")
+    assert second == first
+    assert _guard_count(second) == 1

--- a/xrcg/generator/python_codegen_postprocessor.py
+++ b/xrcg/generator/python_codegen_postprocessor.py
@@ -10,6 +10,10 @@ _JSON_TO_BYTES_PATTERN = re.compile(
     r"(?P<indent>[ \t]*)if base_content_type == 'application/json':\n"
     r"(?P<disable>(?P=indent)    #pylint: disable=no-member\n)?"
     r"(?P=indent)    result = self\.to_json\(\)\n"
+    r"(?!"
+    r"(?:(?P=indent)    #pylint: enable=no-member\n)?"
+    r"(?P=indent)    if isinstance\(result, str\):\n"
+    r")"
     r"(?P<enable>(?P=indent)    #pylint: enable=no-member\n)?",
     re.MULTILINE,
 )


### PR DESCRIPTION
## Summary

Fixes #501. pply_python_avrotize_fixes injected a `str -> bytes` guard into the `application/json` branch of `to_byte_array` **non-idempotently**. The regex matched only up to the optional `#pylint: enable=no-member` line and did not inspect what followed, so regenerating into a non-empty output directory re-matched an already-guarded branch and appended a duplicate guard on every run (2, 3, ... copies).

## Fix

Anchor a negative lookahead **immediately after** the `result = self.to_json()` line that absorbs the optional `#pylint: enable` comment and rejects the match when the `if isinstance(result, str):` guard already follows.

Note: the negative lookahead suggested in the issue (placed *after* the optional `enable` group) is insufficient on its own — the optional group backtracks around the guard check, letting the match succeed by not consuming the `enable` comment. Placing the lookahead **before** the optional group (and having it absorb the optional comment internally) closes that gap. The added `test_pattern_is_idempotent` fails against the issue's suggested regex and passes against this one.

## Tests

New `test/codegen/test_python_postprocessor.py` (4 deterministic, broker-free unit tests):
- first pass injects exactly one guard,
- second pass is a no-op (idempotent),
- idempotent when the pylint markers are absent,
- on-disk `apply_python_avrotize_fixes` re-run leaves the file byte-identical (reproduces the reported in-place-regen scenario at the function level).

All 4 pass; each idempotency test fails without the fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
