### PR TITLE
ci: pin @asyncapi/cli to 5.0.7 (last CommonJS release) to fix test-other

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,10 @@ jobs:
         python -m build --sdist --wheel --outdir dist
     - name: Install Test Prerequisites
       run: |
-        npm install -g @asyncapi/cli@latest
+        # @asyncapi/cli 6.x (ESM) fails to load on the CI runner with
+        # "ReferenceError: module is not defined in ES module scope"; pin the
+        # last CommonJS release (5.0.7), which is immune to that failure.
+        npm install -g @asyncapi/cli@5.0.7
         npm install -g @openapitools/openapi-generator-cli
     - name: Check disk space
       run: df -h
@@ -219,7 +222,10 @@ jobs:
     - name: Install Test Prerequisites
       run: |
         npm install -g azure-functions-core-tools@4 --unsafe-perm true 
-        npm install -g @asyncapi/cli@latest
+        # @asyncapi/cli 6.x (ESM) fails to load on the CI runner with
+        # "ReferenceError: module is not defined in ES module scope"; pin the
+        # last CommonJS release (5.0.7), which is immune to that failure.
+        npm install -g @asyncapi/cli@5.0.7
         npm install -g @openapitools/openapi-generator-cli
     - name: Check disk space before tests
       run: df -h


### PR DESCRIPTION
## Problem

The `test-other` CI job fails on **all 12** `test/asyncapi/` validation tests, gating every open PR (#529, #530, #531). Each test shells out to `asyncapi validate <doc>`, which aborts with:

```
ReferenceError: module is not defined in ES module scope
```

## Root cause

`@asyncapi/cli` **6.0.0** migrated the CLI to **ESM**. The current `@latest` (6.0.2) throws the error above when its entrypoint is loaded on the GitHub-hosted `ubuntu-latest` runner. The failure is:

- **Deterministic**, not flaky — plain reruns never pass.
- **Present on both Node 22 and Node 24** in CI (an earlier attempt to bump the runner to Node 24 did *not* fix it).
- **Not reproducible locally** — the same 6.0.2 build validates cleanly on Windows (Node 24.11) and WSL Linux (Node 22.15.1), via both `npx` and global install. The break is specific to the hosted runner's module resolution of the 6.x ESM build.

## Fix

Pin `@asyncapi/cli` to **5.0.7** — the last release before the 6.0 ESM migration. 5.0.7 is CommonJS and therefore structurally immune to the ESM entrypoint error. Applied at both install sites (`test-core` and `test-other`) with an explanatory comment.

Version boundary: `npm view @asyncapi/cli versions` -> `... 5.0.6, 5.0.7, 6.0.0, 6.0.1, 6.0.2`.

Verified locally: `asyncapi validate` on a generated AsyncAPI doc exits 0 with 5.0.7 on Linux Node 22.

## Validation

This PR's own `test-other` run is the decisive proof — it must go green where it previously failed on all asyncapi tests.
