### PR TITLE
Add MQTT v5 Enhanced Authentication (OAUTH2-JWT) to cs/java/ts mqttclient (#470)

### DIFF
--- a/xrcg/templates/cs/mqttclient/src/Tools.cs.jinja
+++ b/xrcg/templates/cs/mqttclient/src/Tools.cs.jinja
@@ -93,6 +93,43 @@ namespace {{ project_name | pascal }}
                 return topicTemplate;
             }
         }
+
+        /// <summary>
+        /// Extension helpers for configuring MQTT v5 Enhanced Authentication
+        /// (OAUTH2-JWT) on an <see cref="MqttClientOptionsBuilder"/>.
+        /// </summary>
+        public static class MqttClientOptionsBuilderExtensions
+        {
+            /// <summary>
+            /// The default MQTT v5 Authentication Method advertised for OAuth2/Entra JWT auth.
+            /// </summary>
+            public const string OAuth2JwtAuthenticationMethod = "OAUTH2-JWT";
+
+            /// <summary>
+            /// Configures the builder with MQTT v5 Enhanced Authentication carrying the
+            /// supplied OAuth2/Entra bearer token (JWT). Brokers such as Azure Event Grid
+            /// Namespaces require the token via the CONNECT Authentication Method /
+            /// Authentication Data properties rather than username/password; presenting it
+            /// as a password silently fails CONNACK and queues publishes locally. This also
+            /// forces protocol version 5.0.0, which is required for the properties to be honored.
+            /// </summary>
+            /// <param name="builder">The options builder to configure.</param>
+            /// <param name="token">The OAuth2/Entra bearer token (JWT).</param>
+            /// <param name="authenticationMethod">The MQTT v5 Authentication Method to advertise (default "OAUTH2-JWT").</param>
+            /// <returns>The same builder for fluent chaining.</returns>
+            public static MqttClientOptionsBuilder WithOAuth2JwtAuthentication(
+                this MqttClientOptionsBuilder builder,
+                string token,
+                string authenticationMethod = OAuth2JwtAuthenticationMethod)
+            {
+                if (builder == null) { throw new ArgumentNullException(nameof(builder)); }
+                if (string.IsNullOrEmpty(token)) { throw new ArgumentException("Token must not be null or empty.", nameof(token)); }
+                if (string.IsNullOrEmpty(authenticationMethod)) { throw new ArgumentException("Authentication method must not be null or empty.", nameof(authenticationMethod)); }
+                return builder
+                    .WithProtocolVersion(MQTTnet.Formatter.MqttProtocolVersion.V500)
+                    .WithEnhancedAuthentication(authenticationMethod, Encoding.UTF8.GetBytes(token));
+            }
+        }
     }
 
     /// <summary>

--- a/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
+++ b/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
@@ -16,6 +16,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using Xunit;
 using Microsoft.Extensions.Logging;
@@ -24,6 +26,7 @@ using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Builders;
 
 using {{ project_name | pascal }};
+using {{ project_name | pascal }}.Tools;
 {%- for messagegroupid, messagegroup in messagegroups.items() %}
 {%- set pascal_group_name = messagegroupid | pascal %}
 using {{ project_name | pascal }}.{{ pascal_group_name | pascal  }};
@@ -377,4 +380,48 @@ namespace {{ project_name | pascal }}.Test
         {%- endfor %}
     }
     {%- endfor %}
+
+    /// <summary>
+    /// Broker-free unit tests for MQTT v5 Enhanced Authentication (OAUTH2-JWT) option building.
+    /// </summary>
+    public class {{ project_name | strip_dots | pascal }}EnhancedAuthenticationTests
+    {
+        [Fact]
+        public void WithOAuth2JwtAuthentication_SetsEnhancedAuthMethodAndData()
+        {
+            var token = "header.payload.signature";
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer("broker.example.com")
+                .WithOAuth2JwtAuthentication(token)
+                .Build();
+
+            Assert.Equal("OAUTH2-JWT", options.AuthenticationMethod);
+            Assert.NotNull(options.AuthenticationData);
+            Assert.True(Encoding.UTF8.GetBytes(token).SequenceEqual(options.AuthenticationData!));
+        }
+
+        [Fact]
+        public void WithOAuth2JwtAuthentication_CustomMethod_IsAdvertised()
+        {
+            var token = "another-token";
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer("broker.example.com")
+                .WithOAuth2JwtAuthentication(token, "CUSTOM-METHOD")
+                .Build();
+
+            Assert.Equal("CUSTOM-METHOD", options.AuthenticationMethod);
+            Assert.True(Encoding.UTF8.GetBytes(token).SequenceEqual(options.AuthenticationData!));
+        }
+
+        [Fact]
+        public void DefaultOptions_HaveNoEnhancedAuthentication()
+        {
+            var options = new MqttClientOptionsBuilder()
+                .WithTcpServer("broker.example.com")
+                .Build();
+
+            Assert.Null(options.AuthenticationMethod);
+            Assert.Null(options.AuthenticationData);
+        }
+    }
 }

--- a/xrcg/templates/cs/mqttclient/{rootdir}README.md.jinja
+++ b/xrcg/templates/cs/mqttclient/{rootdir}README.md.jinja
@@ -188,6 +188,28 @@ var options = new MqttClientOptionsBuilder()
 var client = new {{ class_name }}(options, loggerFactory);
 ```
 
+### OAuth2/Entra Token (MQTT v5 Enhanced Authentication)
+
+Brokers such as **Azure Event Grid Namespaces** require an OAuth2/Entra bearer token (JWT) to be
+presented through the MQTT v5 CONNECT *Authentication Method* (`OAUTH2-JWT`) / *Authentication Data*
+properties, **not** username/password (which silently fails CONNACK and queues publishes locally).
+Use the `WithOAuth2JwtAuthentication` extension from the `{{ project_name | pascal }}.Tools` namespace,
+which sets the authentication method/data and forces protocol version 5.0.0:
+
+```csharp
+using {{ project_name | pascal }}.Tools;
+
+var options = new MqttClientOptionsBuilder()
+    .WithTcpServer("myns.region-1.ts.eventgrid.azure.net", 8883)
+    .WithOAuth2JwtAuthentication(entraAccessToken)   // Authentication Method "OAUTH2-JWT" + token as data
+    .Build();
+
+var client = new MqttClientFactory().CreateMqttClient();
+await client.ConnectAsync(options);
+```
+
+Omit `WithOAuth2JwtAuthentication` for the default token-less (MQTT 3.1.1-compatible) path.
+
 ### TLS/SSL
 
 ```csharp

--- a/xrcg/templates/java/mqttclient/src/main/java/{projectdir}MqttEventClient.java.jinja
+++ b/xrcg/templates/java/mqttclient/src/main/java/{projectdir}MqttEventClient.java.jinja
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.UUID;
+import java.nio.charset.StandardCharsets;
 
 {%- for messagegroupid in root.messagegroups.keys() %}
 {%- set group_package = (package_name ~ "." ~ messagegroupid) | lower | replace('-', '_') -%}
@@ -41,6 +42,35 @@ public class MqttEventClient implements AutoCloseable {
         this.mqttClient = mqttClient;
     }
 
+    /**
+     * The default MQTT v5 Authentication Method advertised for OAuth2/Entra JWT auth.
+     */
+    public static final String DEFAULT_AUTHENTICATION_METHOD = "OAUTH2-JWT";
+
+    /**
+     * Apply MQTT v5 Enhanced Authentication carrying an OAuth2/Entra bearer token
+     * (JWT) to the given connection options. Brokers such as Azure Event Grid
+     * Namespaces require the token via the CONNECT Authentication Method /
+     * Authentication Data properties rather than username/password. When
+     * {@code token} is null or empty the options are returned unchanged, preserving
+     * the default (token-less) connection behavior.
+     *
+     * @param options              The connection options to configure.
+     * @param token                The OAuth2/Entra bearer token (JWT), or null for no enhanced auth.
+     * @param authenticationMethod The MQTT v5 Authentication Method to advertise (defaults to "OAUTH2-JWT" when null/empty).
+     * @return The same options instance for chaining.
+     */
+    public static MqttConnectionOptions applyEnhancedAuthentication(
+            MqttConnectionOptions options, String token, String authenticationMethod) {
+        if (token != null && !token.isEmpty()) {
+            options.setAuthMethod(
+                (authenticationMethod == null || authenticationMethod.isEmpty())
+                    ? DEFAULT_AUTHENTICATION_METHOD : authenticationMethod);
+            options.setAuthData(token.getBytes(StandardCharsets.UTF_8));
+        }
+        return options;
+    }
+
     {%- for messagegroupid, messagegroup in root.messagegroups.items() %}
     {%- set messagegroupname = messagegroupid | pascal | strip_namespace %}
     {%- set group_package = (package_name ~ "." ~ messagegroupid) | lower | replace('-', '_') %}
@@ -57,6 +87,41 @@ public class MqttEventClient implements AutoCloseable {
     public static {{ group_package }}.{{ producer_class }} createProducerFor{{ messagegroupname }}(
             String brokerUrl,
             String clientId) throws MqttException {
+        return createProducerFor{{ messagegroupname }}(brokerUrl, clientId, null, DEFAULT_AUTHENTICATION_METHOD);
+    }
+
+    /**
+     * Create an MQTT 5.0 producer for {{ messagegroupid }} that presents an OAuth2/Entra
+     * bearer token via MQTT v5 Enhanced Authentication (OAUTH2-JWT), as required by
+     * brokers such as Azure Event Grid Namespaces.
+     *
+     * @param brokerUrl The MQTT broker URL (e.g., "tcp://localhost:1883")
+     * @param clientId Optional client ID (null for auto-generated)
+     * @param token OAuth2/Entra bearer token (JWT); null or empty for a token-less connection
+     * @return A configured MQTT producer instance
+     */
+    public static {{ group_package }}.{{ producer_class }} createProducerFor{{ messagegroupname }}(
+            String brokerUrl,
+            String clientId,
+            String token) throws MqttException {
+        return createProducerFor{{ messagegroupname }}(brokerUrl, clientId, token, DEFAULT_AUTHENTICATION_METHOD);
+    }
+
+    /**
+     * Create an MQTT 5.0 producer for {{ messagegroupid }} using MQTT v5 Enhanced
+     * Authentication with a custom Authentication Method.
+     *
+     * @param brokerUrl The MQTT broker URL (e.g., "tcp://localhost:1883")
+     * @param clientId Optional client ID (null for auto-generated)
+     * @param token OAuth2/Entra bearer token (JWT); null or empty for a token-less connection
+     * @param authenticationMethod MQTT v5 Authentication Method to advertise when a token is supplied
+     * @return A configured MQTT producer instance
+     */
+    public static {{ group_package }}.{{ producer_class }} createProducerFor{{ messagegroupname }}(
+            String brokerUrl,
+            String clientId,
+            String token,
+            String authenticationMethod) throws MqttException {
 
         if (clientId == null || clientId.isEmpty()) {
             clientId = "producer-" + UUID.randomUUID();
@@ -66,6 +131,7 @@ public class MqttEventClient implements AutoCloseable {
         MqttConnectionOptions options = new MqttConnectionOptions();
         options.setCleanStart(true);
         options.setAutomaticReconnect(true);
+        applyEnhancedAuthentication(options, token, authenticationMethod);
 
         client.connect(options);
         logger.info("Connected MQTT 5.0 producer to {} with client ID {}", brokerUrl, clientId);
@@ -87,6 +153,49 @@ public class MqttEventClient implements AutoCloseable {
             String brokerUrl,
             String clientId,
             String[] topics) throws MqttException {
+        return createConsumerFor{{ messagegroupname }}(messageConsumer, brokerUrl, clientId, topics, null, DEFAULT_AUTHENTICATION_METHOD);
+    }
+
+    /**
+     * Create an MQTT 5.0 consumer for {{ messagegroupid }} that presents an OAuth2/Entra
+     * bearer token via MQTT v5 Enhanced Authentication (OAUTH2-JWT), as required by
+     * brokers such as Azure Event Grid Namespaces.
+     *
+     * @param messageConsumer The message consumer that handles incoming messages
+     * @param brokerUrl The MQTT broker URL
+     * @param clientId Optional client ID (null for auto-generated)
+     * @param topics List of topics to subscribe to
+     * @param token OAuth2/Entra bearer token (JWT); null or empty for a token-less connection
+     * @return A configured MQTT event client instance
+     */
+    public static MqttEventClient createConsumerFor{{ messagegroupname }}(
+            {{ group_package }}.{{ consumer_class }} messageConsumer,
+            String brokerUrl,
+            String clientId,
+            String[] topics,
+            String token) throws MqttException {
+        return createConsumerFor{{ messagegroupname }}(messageConsumer, brokerUrl, clientId, topics, token, DEFAULT_AUTHENTICATION_METHOD);
+    }
+
+    /**
+     * Create an MQTT 5.0 consumer for {{ messagegroupid }} using MQTT v5 Enhanced
+     * Authentication with a custom Authentication Method.
+     *
+     * @param messageConsumer The message consumer that handles incoming messages
+     * @param brokerUrl The MQTT broker URL
+     * @param clientId Optional client ID (null for auto-generated)
+     * @param topics List of topics to subscribe to
+     * @param token OAuth2/Entra bearer token (JWT); null or empty for a token-less connection
+     * @param authenticationMethod MQTT v5 Authentication Method to advertise when a token is supplied
+     * @return A configured MQTT event client instance
+     */
+    public static MqttEventClient createConsumerFor{{ messagegroupname }}(
+            {{ group_package }}.{{ consumer_class }} messageConsumer,
+            String brokerUrl,
+            String clientId,
+            String[] topics,
+            String token,
+            String authenticationMethod) throws MqttException {
 
         if (clientId == null || clientId.isEmpty()) {
             clientId = "consumer-" + UUID.randomUUID();
@@ -96,6 +205,7 @@ public class MqttEventClient implements AutoCloseable {
         MqttConnectionOptions options = new MqttConnectionOptions();
         options.setCleanStart(true);
         options.setAutomaticReconnect(true);
+        applyEnhancedAuthentication(options, token, authenticationMethod);
 
         client.setCallback(new MqttCallback() {
             @Override

--- a/xrcg/templates/java/mqttclient/src/test/java/MqttEnhancedAuthenticationTest.java.jinja
+++ b/xrcg/templates/java/mqttclient/src/test/java/MqttEnhancedAuthenticationTest.java.jinja
@@ -1,0 +1,58 @@
+{%- import 'util.jinja.include' as util -%}
+{{ util.CommonFileHeader() }}
+
+{%- set package_name = project_name | lower | replace('-', '_') %}
+package {{ package_name }};
+
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Broker-free unit tests for MQTT v5 Enhanced Authentication (OAUTH2-JWT).
+ * These verify the token path sets the CONNECT Authentication Method /
+ * Authentication Data and that the default (token-less) path is unchanged.
+ */
+public class MqttEnhancedAuthenticationTest {
+
+    @Test
+    void applyEnhancedAuthentication_setsAuthMethodAndData() {
+        String token = "header.payload.signature";
+        MqttConnectionOptions options = new MqttConnectionOptions();
+        MqttEventClient.applyEnhancedAuthentication(options, token, MqttEventClient.DEFAULT_AUTHENTICATION_METHOD);
+
+        assertEquals("OAUTH2-JWT", options.getAuthMethod());
+        assertArrayEquals(token.getBytes(StandardCharsets.UTF_8), options.getAuthData());
+    }
+
+    @Test
+    void applyEnhancedAuthentication_customMethodIsAdvertised() {
+        String token = "another-token";
+        MqttConnectionOptions options = new MqttConnectionOptions();
+        MqttEventClient.applyEnhancedAuthentication(options, token, "CUSTOM-METHOD");
+
+        assertEquals("CUSTOM-METHOD", options.getAuthMethod());
+        assertArrayEquals(token.getBytes(StandardCharsets.UTF_8), options.getAuthData());
+    }
+
+    @Test
+    void applyEnhancedAuthentication_nullToken_leavesOptionsUnchanged() {
+        MqttConnectionOptions options = new MqttConnectionOptions();
+        MqttEventClient.applyEnhancedAuthentication(options, null, MqttEventClient.DEFAULT_AUTHENTICATION_METHOD);
+
+        assertNull(options.getAuthMethod());
+        assertNull(options.getAuthData());
+    }
+
+    @Test
+    void applyEnhancedAuthentication_emptyMethodDefaultsToOauth2Jwt() {
+        String token = "tok";
+        MqttConnectionOptions options = new MqttConnectionOptions();
+        MqttEventClient.applyEnhancedAuthentication(options, token, "");
+
+        assertEquals("OAUTH2-JWT", options.getAuthMethod());
+    }
+}

--- a/xrcg/templates/java/mqttclient/{rootdir}README.md.jinja
+++ b/xrcg/templates/java/mqttclient/{rootdir}README.md.jinja
@@ -192,6 +192,25 @@ client.connect();
     .build();
 ```
 
+### OAuth2/Entra Token (MQTT v5 Enhanced Authentication)
+
+Brokers such as **Azure Event Grid Namespaces** require an OAuth2/Entra bearer token (JWT) via the
+MQTT v5 CONNECT *Authentication Method* (`OAUTH2-JWT`) / *Authentication Data* properties, **not**
+username/password. Pass the token to any producer or consumer factory (an extra argument enables
+MQTT v5 Enhanced Authentication; omit it or pass `null` for the default token-less path):
+
+```java
+var producer = MqttEventClient.createProducerForOrders(
+    "ssl://myns.region-1.ts.eventgrid.azure.net:8883", clientId, entraAccessToken);
+
+// custom Authentication Method:
+var consumer = MqttEventClient.createConsumerForOrders(
+    handler, brokerUrl, clientId, topics, entraAccessToken, "OAUTH2-JWT");
+```
+
+`MqttEventClient.applyEnhancedAuthentication(options, token, authMethod)` is also exposed for
+callers that build their own `MqttConnectionOptions`.
+
 ### TLS/SSL
 
 ```java

--- a/xrcg/templates/ts/mqttclient/src/client.ts.jinja
+++ b/xrcg/templates/ts/mqttclient/src/client.ts.jinja
@@ -164,6 +164,36 @@ export class {{ class_name }} {
         });
     }
 
+    /**
+     * Build MQTT v5 connection options that present an OAuth2/Entra bearer token
+     * (JWT) via Enhanced Authentication. Brokers such as Azure Event Grid Namespaces
+     * require the token through the CONNECT Authentication Method / Authentication
+     * Data properties rather than username/password; presenting it as a password
+     * silently fails CONNACK and queues publishes locally. The returned options force
+     * `protocolVersion: 5`, which is required for these properties to be honored.
+     *
+     * @param token The OAuth2/Entra bearer token (JWT).
+     * @param authenticationMethod The MQTT v5 Authentication Method (default 'OAUTH2-JWT').
+     * @param base Optional base options to extend (its `properties` are preserved).
+     */
+    static buildEnhancedAuthenticationOptions(
+        token: string,
+        authenticationMethod: string = 'OAUTH2-JWT',
+        base?: mqtt.IClientOptions
+    ): mqtt.IClientOptions {
+        if (!token) {
+            throw new Error('token must be a non-empty string');
+        }
+        const options: mqtt.IClientOptions = { ...(base ?? {}) };
+        options.protocolVersion = 5;
+        options.properties = {
+            ...(options.properties ?? {}),
+            authenticationMethod,
+            authenticationData: Buffer.from(token, 'utf8'),
+        };
+        return options;
+    }
+
     /** Gets the current topic mappings. */
     getTopicMappings(): Record<string, string> {
         return { ...this.topicMappings };

--- a/xrcg/templates/ts/mqttclient/test/client.test.ts.jinja
+++ b/xrcg/templates/ts/mqttclient/test/client.test.ts.jinja
@@ -55,6 +55,24 @@ describe('{{ test_class_name }}', () => {
         await new Promise<void>((resolve) => tcpServer.close(() => resolve()));
     }, 10000);
 
+    it('buildEnhancedAuthenticationOptions sets MQTT v5 OAUTH2-JWT auth', () => {
+        const token = 'header.payload.signature';
+        const options = {{ class_name }}.buildEnhancedAuthenticationOptions(token);
+        expect(options.protocolVersion).toBe(5);
+        expect(options.properties?.authenticationMethod).toBe('OAUTH2-JWT');
+        expect(options.properties?.authenticationData).toEqual(Buffer.from(token, 'utf8'));
+    });
+
+    it('buildEnhancedAuthenticationOptions supports a custom method and preserves base options', () => {
+        const token = 'another-token';
+        const base: mqtt.IClientOptions = { clientId: 'my-client', properties: { sessionExpiryInterval: 30 } };
+        const options = {{ class_name }}.buildEnhancedAuthenticationOptions(token, 'CUSTOM-METHOD', base);
+        expect(options.clientId).toBe('my-client');
+        expect(options.properties?.sessionExpiryInterval).toBe(30);
+        expect(options.properties?.authenticationMethod).toBe('CUSTOM-METHOD');
+        expect(options.properties?.authenticationData).toEqual(Buffer.from(token, 'utf8'));
+    });
+
     {%- for messageid, message in messagegroup.messages.items() %}
     {%- set messagename = messageid | strip_namespace | pascal %}
     {%- set body_type = util.body_type(data_project_name, root, message) %}

--- a/xrcg/templates/ts/mqttclient/{rootdir}README.md.jinja
+++ b/xrcg/templates/ts/mqttclient/{rootdir}README.md.jinja
@@ -101,6 +101,21 @@ const client = new {{ class_name }}('mqtt://broker.example.com:1883', {
 });
 ```
 
+### 4. OAuth2/Entra Token (MQTT v5 Enhanced Authentication)
+
+Brokers such as **Azure Event Grid Namespaces** require an OAuth2/Entra bearer token (JWT) via the
+MQTT v5 CONNECT *Authentication Method* (`OAUTH2-JWT`) / *Authentication Data* properties, **not**
+username/password (which silently fails CONNACK). Build the options with the static
+`buildEnhancedAuthenticationOptions` helper, which sets the auth method/data and forces
+`protocolVersion: 5`:
+
+```typescript
+const options = {{ class_name }}.buildEnhancedAuthenticationOptions(entraAccessToken);
+const client = new {{ class_name }}('mqtts://myns.region-1.ts.eventgrid.azure.net:8883', options);
+```
+
+Omit the helper for the default token-less path.
+
 ## Available Event Handlers
 
 {% for messageid, message in messagegroup.messages.items() -%}


### PR DESCRIPTION
Mirrors the Python mqttclient MQTT v5 Enhanced Authentication support (#468) into the **C#**, **Java**, and **TypeScript** `mqttclient` templates. Closes #470.

## Why
Brokers such as **Azure Event Grid Namespaces** require an OAuth2/Entra bearer token (JWT) to be presented through the MQTT v5 CONNECT **Authentication Method** (`OAUTH2-JWT`) / **Authentication Data** properties. They reject username/password (silent CONNACK failure). Python already supports this; C#/Java/TS did not.

## What
Each language gets a static seam that augments its native connect options with the auth method + token bytes (defaulting the method to `OAUTH2-JWT`), plus broker-free regression tests. The default token-less path is unchanged.

| Lang | API added | Tests |
|------|-----------|-------|
| C# | `MqttClientOptionsBuilder.WithOAuth2JwtAuthentication(token, method="OAUTH2-JWT")` (forces protocol v5.0.0) in `Tools.cs` | 3 broker-free xUnit `[Fact]`s |
| Java | `MqttEventClient.applyEnhancedAuthentication(options, token, method)` + producer/consumer factory overloads accepting an optional token/method | 4 broker-free JUnit tests (standalone, no Testcontainers) |
| TS | `static buildEnhancedAuthenticationOptions(token, method="OAUTH2-JWT", base?)` on each `*MqttClient` class (sets `protocolVersion: 5` + `properties.authentication*`) | 2 broker-free jest tests per messagegroup |

READMEs for all three languages document the new usage and the Event Grid rationale.

## Validation (local, broker-free)
Generated `mqttclient` for `contoso-erp` and ran only the enhanced-auth tests:
- **C#**: build OK, 3/3 pass.
- **Java**: `BUILD SUCCESS`, 4/4 pass.
- **TS**: compiles clean, 14 pass (2 x 7 groups).

The new tests are broker-free (no Docker) and run inside the existing `test-csharp` / `test-java` / `test-typescript` CI suites.

Go is out of scope (no `mqttclient` template).