### PR TITLE
AMQP binary content mode (Java) + MQTT topic-placeholder dedup (C#) (#535)

### DIFF
--- a/test/codegen/test_codegen.py
+++ b/test/codegen/test_codegen.py
@@ -342,6 +342,101 @@ def test_codegen_py_kafkaproducer_keeps_jstruct_exports_with_unused_avro_schemas
         shutil.rmtree(work_dir, ignore_errors=True)
 
 
+def test_codegen_cs_mqttclient_dedups_repeated_topic_placeholder():
+    """Regression test for duplicate URI-template placeholders in MQTT topic templates.
+
+    A transport-native MQTT ``topic_name`` that references the same placeholder more
+    than once (for example ``{region}`` twice) must not emit that method parameter
+    twice. Before the fix the generated ``Send*Async`` signature contained
+    ``string region, string region`` which is a C# CS0100 duplicate-parameter
+    compile error. This mirrors the CloudEvents-path de-duplication from issue #471,
+    applied to the transport-native topic-template argument collection.
+    """
+    work_dir = tempfile.mkdtemp()
+    try:
+        definitions_path = os.path.join(work_dir, 'mqtt-dup-topic.xreg.json')
+        output_dir = os.path.join(work_dir, 'out')
+
+        document = {
+            "$schema": "https://xregistry.io/schema/xregistry_messaging_catalog.json",
+            "messagegroups": {
+                "Contoso.Telemetry": {
+                    "protocol": "MQTT/5.0",
+                    "messages": {
+                        "Contoso.Telemetry.VehicleEvent": {
+                            "name": "VehicleEvent",
+                            "protocol": "MQTT/5.0",
+                            "protocoloptions": {
+                                "topic_name": "contoso/telemetry/{region}/vehicles/{region}/vp"
+                            },
+                            "dataschemaformat": "JsonStructure/draft-02",
+                            "dataschemauri": "#/schemagroups/Contoso.Telemetry.jstruct/schemas/Contoso.Telemetry.VehicleEvent"
+                        }
+                    }
+                }
+            },
+            "schemagroups": {
+                "Contoso.Telemetry.jstruct": {
+                    "schemas": {
+                        "Contoso.Telemetry.VehicleEvent": {
+                            "name": "VehicleEvent",
+                            "format": "JsonStructure/draft-02",
+                            "defaultversionid": "1",
+                            "versions": {
+                                "1": {
+                                    "format": "JsonStructure/draft-02",
+                                    "schema": {
+                                        "$schema": "https://json-structure.org/meta/core/v0/#",
+                                        "name": "VehicleEvent",
+                                        "type": "object",
+                                        "properties": {
+                                            "oper": {"type": "int32"},
+                                            "veh": {"type": "int32"}
+                                        },
+                                        "required": ["oper", "veh"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        with open(definitions_path, 'w', encoding='utf-8') as handle:
+            json.dump(document, handle, indent=2)
+
+        sys.argv = [
+            'xrcg', 'generate',
+            '--style', 'mqttclient',
+            '--language', 'cs',
+            '--definitions', definitions_path,
+            '--output', output_dir,
+            '--projectname', 'MqttDupTopic'
+        ]
+        assert xrcg.cli() == 0
+
+        producer_path = None
+        for dirpath, _dirnames, filenames in os.walk(output_dir):
+            if 'Producer.cs' in filenames:
+                producer_path = os.path.join(dirpath, 'Producer.cs')
+                break
+        assert producer_path is not None, f"Producer.cs not found under {output_dir}"
+
+        with open(producer_path, 'r', encoding='utf-8') as handle:
+            producer_contents = handle.read()
+
+        # The repeated {region} placeholder must yield a single parameter, not two.
+        assert 'string region, string region' not in producer_contents, (
+            "Duplicate 'string region' parameter (C# CS0100) emitted for a repeated "
+            "topic placeholder"
+        )
+        # ...but the parameter must still be present (no over-de-duplication).
+        assert 'string region' in producer_contents
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
 def test_extract_schema_info_keeps_names_for_top_level_schemagroup_refs():
     """Top-level schemagroup refs must retain class and namespace metadata.
 

--- a/xrcg/templates/cs/mqttclient/src/Producer.cs.jinja
+++ b/xrcg/templates/cs/mqttclient/src/Producer.cs.jinja
@@ -105,7 +105,7 @@ namespace {{ groupname | concat_namespace(project_name) | pascal }}
         {%- endif %}
         {%- set _topic_phs = default_topic | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
         {%- if _topic_phs %}
-            {%- for _ph in _topic_phs if _ph not in _uriarg_names %}
+            {%- for _ph in _topic_phs if _ph not in _uriarg_names and _ph not in _extra_topic_args %}
                 {%- set _ = _extra_topic_args.append(_ph) %}
             {%- endfor %}
         {%- endif %}

--- a/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
+++ b/xrcg/templates/cs/mqttclient/test/ClientTest.cs.jinja
@@ -299,7 +299,7 @@ namespace {{ project_name | pascal }}.Test
         {%- endif %}
         {%- set _topic_phs = _dft.val | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
         {%- if _topic_phs %}
-            {%- for _ph in _topic_phs if _ph not in _uriarg_names %}
+            {%- for _ph in _topic_phs if _ph not in _uriarg_names and _ph not in _extra_topic_args %}
                 {%- set _ = _extra_topic_args.append(_ph) %}
             {%- endfor %}
         {%- endif %}

--- a/xrcg/templates/java/amqpproducer/src/main/java/{classdir}EventProducer.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/main/java/{classdir}EventProducer.java.jinja
@@ -42,6 +42,9 @@ public class {{ class_name }} {
     private final Consumer<io.cloudevents.CloudEvent> beforeSend;
     {%- endif %}
     private final AmqpProducer endpoint;
+    {%- if uses_cloudevents_message %}
+    private AmqpContentMode contentMode = AmqpContentMode.STRUCTURED;
+    {%- endif %}
     
     private {{ class_name }}(AmqpProducer endpoint{%- if uses_cloudevents_message -%}, Consumer<io.cloudevents.CloudEvent> beforeSend{%- endif -%}) {
         this.endpoint = endpoint;
@@ -49,6 +52,20 @@ public class {{ class_name }} {
         this.beforeSend = beforeSend;
         {%- endif %}
     }
+    {%- if uses_cloudevents_message %}
+    
+    /**
+     * Sets the CloudEvents AMQP content mode used for subsequent sends
+     * (default: {@link AmqpContentMode#STRUCTURED}).
+     *
+     * @param contentMode the content mode to use
+     * @return this producer, for fluent chaining
+     */
+    public {{ class_name }} withContentMode(AmqpContentMode contentMode) {
+        this.contentMode = contentMode;
+        return this;
+    }
+    {%- endif %}
     
     {%- if root.endpoints %}
     {%- for endpointid, endpoint in root.endpoints.items() %}
@@ -162,10 +179,18 @@ public class {{ class_name }} {
             beforeSend.accept(cloudEvent);
         }
         
-        // Convert CloudEvent to ProtonJ2 message
-        byte[] cloudEventBytes = {{ cloudEvents.SerializeCloudEvent("cloudEvent") }};
-        Message<?> amqpMessage = Message.create(cloudEventBytes);
-        amqpMessage.contentType("application/cloudevents+json");
+        // Convert CloudEvent to ProtonJ2 message using the configured content mode
+        Message<?> amqpMessage;
+        if (this.contentMode == AmqpContentMode.BINARY) {
+            // Binary content mode: data in the body, CE attributes as cloudEvents:* properties
+            amqpMessage = AmqpProducer.buildBinaryCloudEventMessage(cloudEvent, dataBytes);
+        } else {
+            // Structured content mode: whole CloudEvent serialized as application/cloudevents+json
+            byte[] cloudEventBytes = {{ cloudEvents.SerializeCloudEvent("cloudEvent") }};
+            Message<byte[]> structuredMessage = Message.create(cloudEventBytes);
+            structuredMessage.contentType("application/cloudevents+json");
+            amqpMessage = structuredMessage;
+        }
         
         endpoint.send(amqpMessage);
         

--- a/xrcg/templates/java/amqpproducer/src/main/java/{projectdir}AmqpContentMode.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/main/java/{projectdir}AmqpContentMode.java.jinja
@@ -1,0 +1,24 @@
+{%- import "util.jinja.include" as util -%}
+{{ util.CommonFileHeader() }}
+
+package {{ project_name | lower | replace('-', '_') }};
+
+/**
+ * CloudEvents AMQP content mode used when sending events.
+ *
+ * <ul>
+ *   <li>{@link #STRUCTURED} (default) &mdash; the whole CloudEvent (attributes and data) is
+ *       serialized into the AMQP message body as {@code application/cloudevents+json}.</li>
+ *   <li>{@link #BINARY} &mdash; the event data is the AMQP message body and the CloudEvents
+ *       attributes are carried as {@code cloudEvents:*} AMQP application properties
+ *       (CloudEvents AMQP 1.0.2 binary content mode). Use this for brokers that route or
+ *       filter on CloudEvents application properties.</li>
+ * </ul>
+ */
+public enum AmqpContentMode {
+    /** Whole CloudEvent serialized as {@code application/cloudevents+json} in the message body. */
+    STRUCTURED,
+
+    /** Event data in the body; CloudEvents attributes as {@code cloudEvents:*} application properties. */
+    BINARY
+}

--- a/xrcg/templates/java/amqpproducer/src/main/java/{projectdir}AmqpProducer.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/main/java/{projectdir}AmqpProducer.java.jinja
@@ -1,6 +1,7 @@
 {%- import "util.jinja.include" as util -%}
 {%- import "cloudevents.jinja.include" as cloudEvents -%}
 {%- import "amqp.jinja.include" as amqp -%}
+{%- set uses_cloudevents_message = (root | exists("envelope","CloudEvents/1.0")) %}
 {{ util.CommonFileHeader() }}
 
 package {{ project_name | lower | replace('-', '_') }};
@@ -81,6 +82,45 @@ class AmqpProducer {
             throw lastException;
         }
     }
+    {%- if uses_cloudevents_message %}
+    
+    /**
+     * Builds a ProtonJ2 message for a CloudEvent using the AMQP binary content mode:
+     * the serialized event data becomes the message body and the CloudEvents attributes
+     * are carried as {@code cloudEvents:*} AMQP application properties
+     * (CloudEvents AMQP 1.0.2 binary content mode).
+     *
+     * @param cloudEvent the CloudEvent whose attributes are mapped to application properties
+     * @param dataBytes  the serialized event data used as the AMQP message body
+     * @return a ProtonJ2 message in CloudEvents binary content mode
+     */
+    static Message<byte[]> buildBinaryCloudEventMessage(io.cloudevents.CloudEvent cloudEvent, byte[] dataBytes) throws org.apache.qpid.protonj2.client.exceptions.ClientException {
+        Message<byte[]> message = Message.create(dataBytes);
+        if (cloudEvent.getDataContentType() != null) {
+            message.contentType(cloudEvent.getDataContentType());
+        }
+        message.property("cloudEvents:specversion", cloudEvent.getSpecVersion().toString());
+        message.property("cloudEvents:id", cloudEvent.getId());
+        message.property("cloudEvents:type", cloudEvent.getType());
+        message.property("cloudEvents:source", cloudEvent.getSource().toString());
+        if (cloudEvent.getSubject() != null) {
+            message.property("cloudEvents:subject", cloudEvent.getSubject());
+        }
+        if (cloudEvent.getTime() != null) {
+            message.property("cloudEvents:time", cloudEvent.getTime().toString());
+        }
+        if (cloudEvent.getDataSchema() != null) {
+            message.property("cloudEvents:dataschema", cloudEvent.getDataSchema().toString());
+        }
+        for (String extensionName : cloudEvent.getExtensionNames()) {
+            Object extensionValue = cloudEvent.getExtension(extensionName);
+            if (extensionValue != null) {
+                message.property("cloudEvents:" + extensionName, extensionValue.toString());
+            }
+        }
+        return message;
+    }
+    {%- endif %}
     
     /**
      * Gets or creates a connection to the specified endpoint

--- a/xrcg/templates/java/amqpproducer/src/test/java/{projectdir}AmqpBinaryContentModeTest.java.jinja
+++ b/xrcg/templates/java/amqpproducer/src/test/java/{projectdir}AmqpBinaryContentModeTest.java.jinja
@@ -1,0 +1,79 @@
+{%- import "util.jinja.include" as util -%}
+{{ util.CommonFileHeader() }}
+
+{%- set package_name = project_name | lower | replace('-', '_') %}
+{%- set uses_cloudevents_message = (root | exists("envelope","CloudEvents/1.0")) %}
+package {{ package_name }};
+
+{%- if uses_cloudevents_message %}
+import org.junit.jupiter.api.Test;
+import org.apache.qpid.protonj2.client.Message;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+{%- endif %}
+
+/**
+ * Broker-free unit tests for the CloudEvents AMQP binary content mode
+ * ({@link AmqpContentMode#BINARY}) message mapping.
+ */
+public class AmqpBinaryContentModeTest {
+{%- if uses_cloudevents_message %}
+
+    @Test
+    public void binaryModeMapsCloudEventAttributesToApplicationProperties() throws Exception {
+        byte[] data = "{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8);
+        CloudEvent cloudEvent = CloudEventBuilder.v1()
+            .withId("test-id-1")
+            .withType("com.example.test")
+            .withSource(URI.create("/test/source"))
+            .withSubject("test-subject")
+            .withTime(OffsetDateTime.parse("2024-01-01T00:00:00Z"))
+            .withDataContentType("application/json")
+            .withData(data)
+            .withExtension("traceparent", "00-abc-01")
+            .build();
+
+        Message<byte[]> message = AmqpProducer.buildBinaryCloudEventMessage(cloudEvent, data);
+
+        // Binary mode: the event data is the AMQP body, not a JSON CloudEvent envelope.
+        assertArrayEquals(data, message.body(), "Binary-mode body must be the raw event data");
+        assertEquals(cloudEvent.getDataContentType(), message.contentType(),
+            "Content type must reflect the data content type, not application/cloudevents+json");
+
+        // CloudEvents attributes must be carried as cloudEvents:* application properties.
+        assertEquals(cloudEvent.getSpecVersion().toString(), message.property("cloudEvents:specversion"));
+        assertEquals(cloudEvent.getId(), message.property("cloudEvents:id"));
+        assertEquals(cloudEvent.getType(), message.property("cloudEvents:type"));
+        assertEquals(cloudEvent.getSource().toString(), message.property("cloudEvents:source"));
+        assertEquals(cloudEvent.getSubject(), message.property("cloudEvents:subject"));
+        assertEquals(cloudEvent.getTime().toString(), message.property("cloudEvents:time"));
+        assertEquals("00-abc-01", message.property("cloudEvents:traceparent"));
+    }
+
+    @Test
+    public void binaryModeOmitsOptionalAttributesWhenAbsent() throws Exception {
+        byte[] data = new byte[] { 1, 2, 3 };
+        CloudEvent cloudEvent = CloudEventBuilder.v1()
+            .withId("test-id-2")
+            .withType("com.example.minimal")
+            .withSource(URI.create("/minimal"))
+            .withData(data)
+            .build();
+
+        Message<byte[]> message = AmqpProducer.buildBinaryCloudEventMessage(cloudEvent, data);
+
+        assertArrayEquals(data, message.body());
+        assertEquals("test-id-2", message.property("cloudEvents:id"));
+        assertNull(message.property("cloudEvents:subject"), "Absent subject must not be emitted");
+        assertNull(message.property("cloudEvents:time"), "Absent time must not be emitted");
+    }
+{%- endif %}
+}

--- a/xrcg/templates/java/amqpproducer/{rootdir}README.md.jinja
+++ b/xrcg/templates/java/amqpproducer/{rootdir}README.md.jinja
@@ -1,5 +1,6 @@
 {%- import "util.jinja.include" as util -%}
 {%- set messagegroups = root.messagegroups %}
+{%- set uses_cloudevents_message = (root | exists("envelope","CloudEvents/1.0")) %}
 {% for messagegroupid, messagegroup in messagegroups.items() -%}
 {%- set groupname = messagegroupid | pascal -%}
 {%- set class_name = (groupname | strip_namespace) + "Producer" %}
@@ -302,7 +303,27 @@ builder.withExtension("priority", "high");
 
 CloudEvent cloudEvent = builder.build();
 ```
+{% if uses_cloudevents_message %}
+### CloudEvents Content Mode
 
+CloudEvents can be written to AMQP in two content modes (CloudEvents AMQP 1.0.2 binding):
+
+- **Structured** (default): the entire CloudEvent (attributes and data) is serialized into
+  the AMQP message body as `application/cloudevents+json`.
+- **Binary**: the event data is the AMQP message body and the CloudEvents attributes are
+  carried as `cloudEvents:*` AMQP application properties. Use this for brokers that route or
+  filter on those properties (for example, Azure Event Grid).
+
+Select the mode with `withContentMode(...)` (fluent, returns the producer):
+
+```java
+import {{ project_name | lower | replace('-', '_') }}.AmqpContentMode;
+
+{{ (groupname | strip_namespace) + "EventProducer" }} producer =
+    {{ (groupname | strip_namespace) + "EventProducer" }}.createProducer(credential, beforeSend, options, endpoints)
+        .withContentMode(AmqpContentMode.BINARY);
+```
+{% endif %}
 ## Error Handling
 
 ### Basic Error Handling


### PR DESCRIPTION
Implements both optional follow-ups from the cross-language parity audit tracked in #535. The two items are independent but small, so they ship together.

## Item B — Java `amqpproducer` CloudEvents AMQP binary content mode

Brings the Java `amqpproducer` to parity with the C# and TypeScript producers, which already support the CloudEvents AMQP **binary** content mode. Previously the Java producer only emitted **structured** mode (`application/cloudevents+json` in the body).

- New public enum `AmqpContentMode { STRUCTURED (default), BINARY }`.
- `AmqpProducer.buildBinaryCloudEventMessage(cloudEvent, dataBytes)` maps the CloudEvent attributes (`specversion`, `id`, `type`, `source`, `subject`, `time`, `dataschema` + extensions) to `cloudEvents:*` AMQP application properties, puts the serialized event data in the message body, and sets `contentType` from the data content type (CloudEvents AMQP 1.0.2 binary content mode).
- `EventProducer` gains a `contentMode` field and a fluent `withContentMode(...)` setter. The CloudEvents send path branches: `STRUCTURED` keeps the existing behavior; `BINARY` uses the new helper.
- All new API is guarded by `uses_cloudevents_message`, so non-CloudEvents AMQP producers are unchanged.
- README documents the new content-mode API per messagegroup.

### Tests
New **broker-free** `AmqpBinaryContentModeTest` (2 cases, **no Testcontainers** — does not start a broker) asserting the CloudEvent → application-property mapping, the raw-data body, the content type, and omission of absent optional attributes. Validated locally: `mvn test -Dtest=AmqpBinaryContentModeTest` → 2 pass, no broker started; non-CloudEvents render is an empty class and still compiles.

## Item A — C# `mqttclient` repeated topic-placeholder dedup

Fixes a reachable duplicate-parameter bug in the #487 topic-template logic (not the originally-suspected `DeclareUriTemplateArguments` transport-native macros, which read a `protocoloptions` shape that current samples don't use and are effectively dead for today's manifests).

- `_extra_topic_args` collected topic placeholders checking membership only against `_uriarg_names`, **not against itself**. A `topic_name` that repeats a placeholder (e.g. `contoso/telemetry/{region}/vehicles/{region}/vp`) therefore appended `region` twice, emitting a duplicate `string region, string region` method parameter → C# **CS0100** ("The parameter name 'region' is a duplicate") compile error.
- Fixed in `Producer.cs.jinja` and `ClientTest.cs.jinja` by also excluding already-collected placeholders (mirrors the #471 dedup philosophy).
- Python and TypeScript `mqttclient` accumulate topic placeholders into a **single** `uri_template_vars` list with a membership check against that same list, so they were already immune — no change needed there.

### Tests
New regression test `test_codegen_cs_mqttclient_dedups_repeated_topic_placeholder` (runs in **test-core**, string assertion, no dotnet/CEDISCO feed needed): generates a C# mqttclient from a manifest whose topic repeats `{region}`, then asserts the signature contains a single `string region` and not `string region, string region`. Verified it **passes with the fix and fails without it**.

Refs #535
