### PR TITLE
Add live Testcontainers integration tests for Go messaging styles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -245,6 +245,7 @@ jobs:
   # Go tests - compile-only verification of generated Go SDKs (no Docker)
   test-go:
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
@@ -265,6 +266,12 @@ jobs:
     - name: Run Go tests
       run: |
         pytest -v test/go/
-    - name: Report disk space after tests
+    - name: Clean up Docker resources
+      if: always()
+      run: |
+        docker ps -aq | xargs -r docker rm -f || true
+        docker images -q | xargs -r docker rmi -f || true
+        docker system prune -af --volumes || true
+    - name: Report disk space after cleanup
       if: always()
       run: df -h

--- a/test/go/test_go.py
+++ b/test/go/test_go.py
@@ -85,27 +85,30 @@ def run_go_test(xreg_file: str, output_dir: str, projectname: str, style: str):
         
         print(f"Go code compiled successfully: {project_dir}")
 
-        # Compile the generated test files as well. `go build` ignores *_test.go,
-        # so use `go test -run "^$"` to type-check/compile the tests without
-        # running any of them (keeps this harness broker-free / Docker-free).
-        print(f"Compiling Go tests in {project_dir}")
+        # Run the generated tests. Live-broker styles (kafka/mqtt/amqp) use
+        # Testcontainers and require Docker; they skip automatically when Docker
+        # is unavailable (via testcontainers.SkipIfProviderIsNotHealthy). Mock-based
+        # styles (eventhubs/servicebus) and the HTTP producer run without Docker.
+        # A generous -timeout is needed because live-broker tests start a fresh
+        # container per message and can take several minutes for large samples.
+        print(f"Running Go tests in {project_dir}")
         result = subprocess.run(
-            ['go', 'test', '-run', '^$', './...'],
+            ['go', 'test', '-timeout', '30m', './...'],
             cwd=project_dir,
             capture_output=True,
             text=True,
-            timeout=300
+            timeout=2400
         )
 
         if result.returncode != 0:
-            print(f"go test (compile) stdout: {result.stdout}")
-            print(f"go test (compile) stderr: {result.stderr}")
-            pytest.fail(f"go test compilation failed with return code {result.returncode}")
+            print(f"go test stdout: {result.stdout}")
+            print(f"go test stderr: {result.stderr}")
+            pytest.fail(f"go test failed with return code {result.returncode}")
 
-        print(f"Go tests compiled successfully: {project_dir}")
+        print(f"Go tests passed: {project_dir}")
         
     except subprocess.TimeoutExpired:
-        pytest.fail("Go build timed out after 300 seconds")
+        pytest.fail("Go test run timed out after 2400 seconds")
     except Exception as e:
         pytest.fail(f"Test failed with exception: {str(e)}")
 

--- a/xrcg/templates/go/amqpconsumer/go.mod.jinja
+++ b/xrcg/templates/go/amqpconsumer/go.mod.jinja
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/username/{{ data_project_name | snake }} v0.0.0
 	github.com/stretchr/testify v1.8.4
+	github.com/testcontainers/testcontainers-go v0.27.0
 )
 
 replace github.com/username/{{ data_project_name | snake }} => ../{{ data_project_name }}

--- a/xrcg/templates/go/amqpconsumer/{testdir}consumer_test.go.jinja
+++ b/xrcg/templates/go/amqpconsumer/{testdir}consumer_test.go.jinja
@@ -11,11 +11,14 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	amqp "github.com/Azure/go-amqp"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	{{ data_project_name | snake }} "github.com/username/{{ data_project_name | snake }}/pkg/{{ data_project_name }}"
 	. "{{ project_name | snake }}"
@@ -46,6 +49,38 @@ func (r *fakeAmqpReceiver) Close(ctx context.Context) error {
 	return nil
 }
 
+func startArtemisConsumerIntegrationTest(t *testing.T) (string, func()) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "apache/activemq-artemis:2.31.2",
+			ExposedPorts: []string{"5672/tcp"},
+			Env: map[string]string{
+				"ARTEMIS_USER":     "artemis",
+				"ARTEMIS_PASSWORD": "artemis",
+			},
+			WaitingFor: wait.ForListeningPort("5672/tcp").WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5672/tcp")
+	require.NoError(t, err)
+
+	cleanup := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, container.Terminate(ctx))
+	}
+	return fmt.Sprintf("amqp://artemis:artemis@%s:%s", host, port.Port()), cleanup
+}
+
 {%- set messagegroups = root.messagegroups %}
 {%- for messagegroupid, messagegroup in messagegroups.items() %}
 {%- set groupname = messagegroupid | pascal | strip_namespace %}
@@ -55,10 +90,11 @@ type mock{{ class_name }}Handler struct {
 	mu     sync.Mutex
 	counts map[string]int
 	errors []error
+	events chan cloudevents.Event
 }
 
 func newMock{{ class_name }}Handler() *mock{{ class_name }}Handler {
-	return &mock{{ class_name }}Handler{counts: make(map[string]int)}
+	return &mock{{ class_name }}Handler{counts: make(map[string]int), events: make(chan cloudevents.Event, 10)}
 }
 
 {%- for messageid, message in messagegroup.messages.items() %}
@@ -69,6 +105,9 @@ func (h *mock{{ class_name }}Handler) Handle{{ messagename }}(ctx context.Contex
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.counts["{{ messageid }}"]++
+	{%- if isCloudEvent %}
+	h.events <- event
+	{%- endif %}
 	return nil
 }
 
@@ -91,6 +130,72 @@ func (h *mock{{ class_name }}Handler) HandleError(ctx context.Context, err error
 {%- set isCloudEvent = cloudEvents.isCloudEvent(first_message) %}
 {%- set content_type = util.get_content_type(first_message) %}
 {%- set event_type = first_message.envelopemetadata.type.value if "type" in first_message.envelopemetadata and first_message.envelopemetadata.type.value else first_message_id %}
+
+func Test{{ class_name }}_IntegrationArtemisRoundTrip(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	{%- if isCloudEvent %}
+	addr, cleanup := startArtemisConsumerIntegrationTest(t)
+	defer cleanup()
+	node := "test.queue"
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	handler := newMock{{ class_name }}Handler()
+	consumer, err := New{{ class_name }}(addr, node, handler)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- consumer.Start(ctx)
+	}()
+
+	var testData {{ message_body_type }}
+	payload, err := testData.ToByteArray({{ content_type }})
+	require.NoError(t, err)
+	body, err := json.Marshal(map[string]any{
+		"specversion":     "1.0",
+		"id":              "test-id",
+		"type":            "{{ event_type }}",
+		"source":          "test-source",
+		"datacontenttype": {{ content_type }},
+		"data":            json.RawMessage(payload),
+	})
+	require.NoError(t, err)
+	ct := "application/cloudevents+json"
+
+	conn, err := amqp.Dial(ctx, addr, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	session, err := conn.NewSession(ctx, nil)
+	require.NoError(t, err)
+	defer session.Close(context.Background())
+	sender, err := session.NewSender(ctx, node, nil)
+	require.NoError(t, err)
+	defer sender.Close(context.Background())
+	require.NoError(t, sender.Send(ctx, &amqp.Message{Data: [][]byte{body}, Properties: &amqp.MessageProperties{ContentType: &ct}}, nil))
+
+	select {
+	case event := <-handler.events:
+		assert.Equal(t, "{{ event_type }}", event.Type())
+		assert.Equal(t, "test-source", event.Source())
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for handler: %v", ctx.Err())
+	}
+
+	cancel()
+	_ = consumer.Close(context.Background())
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled {
+			require.NoError(t, err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("consumer did not stop")
+	}
+	{%- else %}
+	t.Skip("first message is not a CloudEvent")
+	{%- endif %}
+}
 
 func Test{{ class_name }}_ConsumesStructuredCloudEvent(t *testing.T) {
 	{%- if isCloudEvent %}

--- a/xrcg/templates/go/amqpconsumer/{testdir}consumer_test.go.jinja
+++ b/xrcg/templates/go/amqpconsumer/{testdir}consumer_test.go.jinja
@@ -62,7 +62,10 @@ func startArtemisConsumerIntegrationTest(t *testing.T) (string, func()) {
 				"ARTEMIS_USER":     "artemis",
 				"ARTEMIS_PASSWORD": "artemis",
 			},
-			WaitingFor: wait.ForListeningPort("5672/tcp").WithStartupTimeout(2 * time.Minute),
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort("5672/tcp").WithStartupTimeout(3*time.Minute),
+				wait.ForLog("AMQ221007").WithStartupTimeout(3*time.Minute),
+			),
 		},
 		Started: true,
 	})

--- a/xrcg/templates/go/amqpproducer/go.mod.jinja
+++ b/xrcg/templates/go/amqpproducer/go.mod.jinja
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/username/{{ data_project_name | snake }} v0.0.0
 	github.com/stretchr/testify v1.8.4
+	github.com/testcontainers/testcontainers-go v0.27.0
 )
 
 replace github.com/username/{{ data_project_name | snake }} => ../{{ data_project_name }}

--- a/xrcg/templates/go/amqpproducer/{testdir}producer_test.go.jinja
+++ b/xrcg/templates/go/amqpproducer/{testdir}producer_test.go.jinja
@@ -9,11 +9,15 @@ package {{ project_name | snake }}_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
 	amqp "github.com/Azure/go-amqp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	{{ data_project_name | snake }} "github.com/username/{{ data_project_name | snake }}/pkg/{{ data_project_name }}"
 	. "{{ project_name | snake }}"
@@ -34,6 +38,38 @@ func (s *fakeAmqpSender) Close(ctx context.Context) error {
 	return nil
 }
 
+func startArtemisProducerIntegrationTest(t *testing.T) (string, func()) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "apache/activemq-artemis:2.31.2",
+			ExposedPorts: []string{"5672/tcp"},
+			Env: map[string]string{
+				"ARTEMIS_USER":     "artemis",
+				"ARTEMIS_PASSWORD": "artemis",
+			},
+			WaitingFor: wait.ForListeningPort("5672/tcp").WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "5672/tcp")
+	require.NoError(t, err)
+
+	cleanup := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		require.NoError(t, container.Terminate(ctx))
+	}
+	return fmt.Sprintf("amqp://artemis:artemis@%s:%s", host, port.Port()), cleanup
+}
+
 {%- set first_group_id = root.messagegroups.keys() | list | first %}
 {%- set first_group = root.messagegroups.values() | list | first %}
 {%- set groupname = first_group_id | pascal | strip_namespace %}
@@ -50,6 +86,76 @@ func (s *fakeAmqpSender) Close(ctx context.Context) error {
 {%- set needs_source_param = true %}
 {%- endif %}
 {%- endif %}
+
+func Test{{ class_name }}_IntegrationArtemisRoundTrip(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	{%- if isCloudEvent %}
+	addr, cleanup := startArtemisProducerIntegrationTest(t)
+	defer cleanup()
+
+	for _, tc := range []struct {
+		name string
+		mode ContentMode
+	}{
+		{name: "Structured", mode: ContentModeStructured},
+		{name: "Binary", mode: ContentModeBinary},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+			node := fmt.Sprintf("test.queue.%s", tc.mode)
+
+			conn, err := amqp.Dial(ctx, addr, nil)
+			require.NoError(t, err)
+			defer conn.Close()
+			session, err := conn.NewSession(ctx, nil)
+			require.NoError(t, err)
+			defer session.Close(context.Background())
+			receiver, err := session.NewReceiver(ctx, node, nil)
+			require.NoError(t, err)
+			defer receiver.Close(context.Background())
+
+			producer, err := New{{ class_name }}(addr, node)
+			require.NoError(t, err)
+			defer producer.Close(context.Background())
+			producer.SetContentMode(tc.mode)
+			var testData {{ message_body_type }}
+
+			err = producer.Send{{ messagename }}(ctx, testData{% if needs_source_param %}, "test-source"{% endif %}{% if "type" not in first_message.envelopemetadata %}, "{{ first_message_id }}"{% endif %})
+			require.NoError(t, err)
+
+			msg, err := receiver.Receive(ctx, nil)
+			require.NoError(t, err)
+			require.NoError(t, receiver.AcceptMessage(ctx, msg))
+			require.NotNil(t, msg)
+			require.NotEmpty(t, msg.GetData())
+
+			if tc.mode == ContentModeStructured {
+				require.NotNil(t, msg.Properties)
+				require.NotNil(t, msg.Properties.ContentType)
+				assert.Equal(t, "application/cloudevents+json", *msg.Properties.ContentType)
+				var envelope map[string]any
+				require.NoError(t, json.Unmarshal(msg.GetData(), &envelope))
+				assert.Equal(t, "1.0", envelope["specversion"])
+				assert.Equal(t, "{{ first_message.envelopemetadata.type.value if "type" in first_message.envelopemetadata and first_message.envelopemetadata.type.value else first_message_id }}", envelope["type"])
+			} else {
+				require.NotNil(t, msg.ApplicationProperties)
+				foundCloudEventsProperty := false
+				for name := range msg.ApplicationProperties {
+					if len(name) > len("cloudEvents:") && name[:len("cloudEvents:")] == "cloudEvents:" {
+						foundCloudEventsProperty = true
+						break
+					}
+				}
+				assert.True(t, foundCloudEventsProperty)
+				assert.Equal(t, "{{ first_message.envelopemetadata.type.value if "type" in first_message.envelopemetadata and first_message.envelopemetadata.type.value else first_message_id }}", msg.ApplicationProperties["cloudEvents:type"])
+			}
+		})
+	}
+	{%- else %}
+	t.Skip("first message is not a CloudEvent")
+	{%- endif %}
+}
 
 func Test{{ class_name }}_StructuredCloudEventMessage(t *testing.T) {
 	{%- if isCloudEvent %}

--- a/xrcg/templates/go/amqpproducer/{testdir}producer_test.go.jinja
+++ b/xrcg/templates/go/amqpproducer/{testdir}producer_test.go.jinja
@@ -51,7 +51,10 @@ func startArtemisProducerIntegrationTest(t *testing.T) (string, func()) {
 				"ARTEMIS_USER":     "artemis",
 				"ARTEMIS_PASSWORD": "artemis",
 			},
-			WaitingFor: wait.ForListeningPort("5672/tcp").WithStartupTimeout(2 * time.Minute),
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort("5672/tcp").WithStartupTimeout(3*time.Minute),
+				wait.ForLog("AMQ221007").WithStartupTimeout(3*time.Minute),
+			),
 		},
 		Started: true,
 	})

--- a/xrcg/templates/go/kafkaconsumer/consumer.go.jinja
+++ b/xrcg/templates/go/kafkaconsumer/consumer.go.jinja
@@ -46,6 +46,7 @@ type {{ class_name }} struct {
 	reader   *kafka.Reader
 	handler  {{ class_name }}Handler
 	running  bool
+	stopped  bool
 	mu       sync.Mutex
 	stopChan chan struct{}
 }
@@ -123,12 +124,13 @@ func (c *{{ class_name }}) Start(ctx context.Context) error {
 	}
 }
 
-// Stop stops the consumer
+// Stop stops the consumer. It is safe to call multiple times (and after Close).
 func (c *{{ class_name }}) Stop() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	
-	if c.running {
+	if !c.stopped {
+		c.stopped = true
 		close(c.stopChan)
 	}
 }

--- a/xrcg/templates/go/kafkaconsumer/go.mod.jinja
+++ b/xrcg/templates/go/kafkaconsumer/go.mod.jinja
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/username/{{ data_project_name | snake }} v0.0.0
 	github.com/testcontainers/testcontainers-go v0.27.0
+	github.com/testcontainers/testcontainers-go/modules/kafka v0.27.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/xrcg/templates/go/kafkaconsumer/{testdir}consumer_test.go.jinja
+++ b/xrcg/templates/go/kafkaconsumer/{testdir}consumer_test.go.jinja
@@ -16,69 +16,75 @@ import (
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/segmentio/kafka-go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	testcontainers "github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
+	tckafka "github.com/testcontainers/testcontainers-go/modules/kafka"
 	
 	{{ data_project_name | snake }} "github.com/username/{{ data_project_name | snake }}/pkg/{{ data_project_name }}"
 	. "{{ project_name | snake }}"
 )
 
-// setupKafka creates a Kafka container for testing
+// setupKafkaConsumerTest starts a single-node Kafka broker (KRaft mode, no
+// Zookeeper) using the Testcontainers Kafka module and returns its bootstrap
+// server address plus a cleanup function. Topics are auto-created on first use.
 func setupKafkaConsumerTest(t *testing.T) (string, func()) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
-	req := testcontainers.ContainerRequest{
-		Image:        "confluentinc/cp-kafka:7.5.0",
-		ExposedPorts: []string{"9092/tcp", "29092/tcp"},
-		Env: map[string]string{
-			"KAFKA_BROKER_ID":                    "1",
-			"KAFKA_ZOOKEEPER_CONNECT":           "localhost:2181",
-			"KAFKA_ADVERTISED_LISTENERS":        "PLAINTEXT://localhost:29092,PLAINTEXT_INTERNAL://kafka:9092",
-			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT",
-			"KAFKA_INTER_BROKER_LISTENER_NAME":  "PLAINTEXT_INTERNAL",
-			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "1",
-		},
-		WaitingFor: wait.ForListeningPort("9092/tcp"),
-	}
+	ctx := context.Background()
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	kafkaContainer, err := tckafka.RunContainer(ctx, tckafka.WithClusterID("xrcg-test-cluster"))
 	require.NoError(t, err)
 
-	// Get the bootstrap server address
-	host, err := container.Host(ctx)
+	brokers, err := kafkaContainer.Brokers(ctx)
 	require.NoError(t, err)
-	port, err := container.MappedPort(ctx, "29092")
-	require.NoError(t, err)
-
-	bootstrapServer := fmt.Sprintf("%s:%s", host, port.Port())
-
-	// Create test topic
-	conn, err := kafka.Dial("tcp", bootstrapServer)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	err = conn.CreateTopics(kafka.TopicConfig{
-		Topic:             "test-topic",
-		NumPartitions:     1,
-		ReplicationFactor: 1,
-	})
-	if err != nil && err.Error() != "Topic already exists" {
-		require.NoError(t, err)
-	}
+	require.NotEmpty(t, brokers, "expected at least one Kafka broker address")
 
 	cleanup := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		container.Terminate(ctx)
+		_ = kafkaContainer.Terminate(ctx)
 	}
 
-	return bootstrapServer, cleanup
+	return brokers[0], cleanup
+}
+
+// createKafkaTopic creates a single-partition topic up front and waits for its
+// leader to be elected, so produce/consume round-trips are deterministic (the
+// generated client does not enable broker-side auto-creation).
+func createKafkaTopic(t *testing.T, bootstrapServer, topic string) {
+	client := &kafka.Client{Addr: kafka.TCP(bootstrapServer)}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	topicConfig := kafka.TopicConfig{
+		Topic:             topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	}
+	resp, err := client.CreateTopics(ctx, &kafka.CreateTopicsRequest{
+		Topics: []kafka.TopicConfig{topicConfig},
+	})
+	require.NoError(t, err)
+	require.NoError(t, resp.Errors[topic])
+
+	require.Eventually(t, func() bool {
+		conn, err := kafka.Dial("tcp", bootstrapServer)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		parts, err := conn.ReadPartitions(topic)
+		if err != nil || len(parts) == 0 {
+			return false
+		}
+		for _, p := range parts {
+			if p.Leader.Host == "" {
+				return false
+			}
+		}
+		return true
+	}, 20*time.Second, 250*time.Millisecond)
 }
 
 {%- set messagegroups = root.messagegroups %}
@@ -121,63 +127,85 @@ func (m *Mock{{ class_name }}Handler) HandleError(ctx context.Context, err error
 {%- set messagename = messageid | pascal | strip_namespace %}
 {%- set message_body_type = util.body_type(data_project_name, root, message) %}
 {%- set topic = kafka.get_topic(message) or messageid %}
+{%- set isCloudEvent = cloudEvents.isCloudEvent(message) %}
 
 func Test{{ class_name }}_{{ messagename }}(t *testing.T) {
 	bootstrapServer, cleanup := setupKafkaConsumerTest(t)
 	defer cleanup()
 
-	// Create producer to send test message
-	writer := &kafka.Writer{
-		Addr:     kafka.TCP(bootstrapServer),
-		Topic:    "{{ topic }}",
-		Balancer: &kafka.LeastBytes{},
-	}
-	defer writer.Close()
+	createKafkaTopic(t, bootstrapServer, "{{ topic }}")
 
-	// Create test data using generated test helper
-	{%- if "[]" in message_body_type %}
-	testData := {{ message_body_type | replace(data_project_name | snake + ".", "") }}(nil)
-	{%- else %}
-	var testData {{ message_body_type }}
-	{%- endif %}
-	dataBytes, _ := json.Marshal(testData)
-
-	// Send test message
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	err := writer.WriteMessages(ctx, kafka.Message{
-		Topic: "{{ topic }}",
-		Value: dataBytes,
-	})
-	require.NoError(t, err)
-
-	// Create consumer with mock handler
+	// Start the consumer BEFORE producing. The generated consumer reads from the
+	// topic tail (StartOffset=Last), so it must join the group and position at
+	// the topic before the message it should observe is written.
 	handler := NewMock{{ class_name }}Handler()
 	consumer, err := New{{ class_name }}(bootstrapServer, "test-group", []string{"{{ topic }}"}, handler)
 	require.NoError(t, err)
 	defer consumer.Close()
 
-	// Start consumer in goroutine
-	consumerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	consumerCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	go func() {
 		consumer.Start(consumerCtx)
 	}()
 
-	// Wait for message to be consumed
-	time.Sleep(2 * time.Second)
+	{%- if "[]" in message_body_type %}
+	testData := {{ message_body_type | replace(data_project_name | snake + ".", "") }}(nil)
+	{%- else %}
+	var testData {{ message_body_type }}
+	{%- endif %}
 
-	// Stop consumer
+	{%- if isCloudEvent %}
+	// Wrap the payload in a structured CloudEvent envelope, matching what the
+	// generated producer emits and what the consumer routes on (by CloudEvent type).
+	event := cloudevents.NewEvent()
+	event.SetID("test-id")
+	event.SetSource("test-source")
+	event.SetType("{{ message.envelopemetadata.type.value }}")
+	require.NoError(t, event.SetData(cloudevents.ApplicationJSON, testData))
+	dataBytes, err := json.Marshal(event)
+	require.NoError(t, err)
+	{%- else %}
+	dataBytes, err := json.Marshal(testData)
+	require.NoError(t, err)
+	{%- endif %}
+
+	// Produce the test message repeatedly in the background. Because the consumer
+	// reads from the tail, we keep publishing until it has joined the group and
+	// positioned at the topic, so at least one copy lands after its offset. This
+	// removes any dependence on consumer-group join timing.
+	produceCtx, stopProducing := context.WithCancel(context.Background())
+	defer stopProducing()
+	go func() {
+		writer := &kafka.Writer{
+			Addr:     kafka.TCP(bootstrapServer),
+			Topic:    "{{ topic }}",
+			Balancer: &kafka.LeastBytes{},
+		}
+		defer writer.Close()
+
+		ticker := time.NewTicker(500 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			_ = writer.WriteMessages(produceCtx, kafka.Message{Value: dataBytes})
+			select {
+			case <-produceCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+
+	// Wait for the message to be consumed by the handler.
+	require.Eventually(t, func() bool {
+		handler.mu.Lock()
+		defer handler.mu.Unlock()
+		return handler.messages["{{ messageid }}"] > 0
+	}, 45*time.Second, 250*time.Millisecond, "Expected handler to receive message")
+
+	stopProducing()
 	consumer.Stop()
-
-	// Verify handler was called
-	handler.mu.Lock()
-	count := handler.messages["{{ messageid }}"]
-	handler.mu.Unlock()
-
-	assert.Greater(t, count, 0, "Expected handler to receive message")
 }
 
 {%- endfor %}

--- a/xrcg/templates/go/kafkaproducer/go.mod.jinja
+++ b/xrcg/templates/go/kafkaproducer/go.mod.jinja
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/username/{{ data_project_name | snake }} v0.0.0
 	github.com/testcontainers/testcontainers-go v0.27.0
+	github.com/testcontainers/testcontainers-go/modules/kafka v0.27.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/xrcg/templates/go/kafkaproducer/{testdir}producer_test.go.jinja
+++ b/xrcg/templates/go/kafkaproducer/{testdir}producer_test.go.jinja
@@ -152,8 +152,12 @@ func Test{{ class_name }}_{{ messagename }}(t *testing.T) {
 	// Binary payload - just verify it's not empty
 	assert.NotEmpty(t, msg.Value, "Expected message to contain data")
 	{%- else %}
-	var receivedData {{ data_project_name | snake }}.{{ message_body_type | replace("*", "") | replace(data_project_name | snake + ".", "") }}
-	if msg.Value[0] == '{' {
+	// msg.Value is a structured CloudEvent envelope. Verify it is well-formed
+	// JSON by decoding into a generic map rather than the typed payload struct:
+	// the envelope's own fields (e.g. "data") can collide with identically
+	// named fields on the payload type.
+	if len(msg.Value) > 0 && msg.Value[0] == '{' {
+		var receivedData map[string]interface{}
 		err = json.Unmarshal(msg.Value, &receivedData)
 		require.NoError(t, err)
 	}

--- a/xrcg/templates/go/kafkaproducer/{testdir}producer_test.go.jinja
+++ b/xrcg/templates/go/kafkaproducer/{testdir}producer_test.go.jinja
@@ -17,68 +17,73 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	testcontainers "github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
+	tckafka "github.com/testcontainers/testcontainers-go/modules/kafka"
 	
 	{{ data_project_name | snake }} "github.com/username/{{ data_project_name | snake }}/pkg/{{ data_project_name }}"
 	. "{{ project_name | snake }}"
 )
 
-// setupKafka creates a Kafka container for testing
+// setupKafka starts a single-node Kafka broker (KRaft mode, no Zookeeper) using
+// the Testcontainers Kafka module and returns its bootstrap server address plus a
+// cleanup function. Topics are auto-created on first use.
 func setupKafka(t *testing.T) (string, func()) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
-	req := testcontainers.ContainerRequest{
-		Image:        "confluentinc/cp-kafka:7.5.0",
-		ExposedPorts: []string{"9092/tcp", "29092/tcp"},
-		Env: map[string]string{
-			"KAFKA_BROKER_ID":                    "1",
-			"KAFKA_ZOOKEEPER_CONNECT":           "localhost:2181",
-			"KAFKA_ADVERTISED_LISTENERS":        "PLAINTEXT://localhost:29092,PLAINTEXT_INTERNAL://kafka:9092",
-			"KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT",
-			"KAFKA_INTER_BROKER_LISTENER_NAME":  "PLAINTEXT_INTERNAL",
-			"KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR": "1",
-		},
-		WaitingFor: wait.ForListeningPort("9092/tcp"),
-	}
+	ctx := context.Background()
 
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
+	kafkaContainer, err := tckafka.RunContainer(ctx, tckafka.WithClusterID("xrcg-test-cluster"))
 	require.NoError(t, err)
 
-	// Get the bootstrap server address
-	host, err := container.Host(ctx)
+	brokers, err := kafkaContainer.Brokers(ctx)
 	require.NoError(t, err)
-	port, err := container.MappedPort(ctx, "29092")
-	require.NoError(t, err)
-
-	bootstrapServer := fmt.Sprintf("%s:%s", host, port.Port())
-
-	// Create test topic
-	conn, err := kafka.Dial("tcp", bootstrapServer)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	err = conn.CreateTopics(
-		kafka.TopicConfig{
-			Topic:             "test-topic",
-			NumPartitions:     1,
-			ReplicationFactor: 1,
-		},
-	)
-	if err != nil && err.Error() != "Topic already exists" {
-		require.NoError(t, err)
-	}
+	require.NotEmpty(t, brokers, "expected at least one Kafka broker address")
 
 	cleanup := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		container.Terminate(ctx)
+		_ = kafkaContainer.Terminate(ctx)
 	}
 
-	return bootstrapServer, cleanup
+	return brokers[0], cleanup
+}
+
+// createKafkaTopic creates a single-partition topic up front and waits for its
+// leader to be elected, so produce/consume round-trips are deterministic (the
+// generated client does not enable broker-side auto-creation).
+func createKafkaTopic(t *testing.T, bootstrapServer, topic string) {
+	client := &kafka.Client{Addr: kafka.TCP(bootstrapServer)}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	topicConfig := kafka.TopicConfig{
+		Topic:             topic,
+		NumPartitions:     1,
+		ReplicationFactor: 1,
+	}
+	resp, err := client.CreateTopics(ctx, &kafka.CreateTopicsRequest{
+		Topics: []kafka.TopicConfig{topicConfig},
+	})
+	require.NoError(t, err)
+	require.NoError(t, resp.Errors[topic])
+
+	require.Eventually(t, func() bool {
+		conn, err := kafka.Dial("tcp", bootstrapServer)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		parts, err := conn.ReadPartitions(topic)
+		if err != nil || len(parts) == 0 {
+			return false
+		}
+		for _, p := range parts {
+			if p.Leader.Host == "" {
+				return false
+			}
+		}
+		return true
+	}, 20*time.Second, 250*time.Millisecond)
 }
 
 {%- set messagegroups = root.messagegroups %}
@@ -103,6 +108,8 @@ func Test{{ class_name }}_{{ messagename }}(t *testing.T) {
 	bootstrapServer, cleanup := setupKafka(t)
 	defer cleanup()
 
+	createKafkaTopic(t, bootstrapServer, "{{ topic }}")
+
 	// Create producer
 	producer, err := New{{ class_name }}(bootstrapServer)
 	require.NoError(t, err)
@@ -113,7 +120,7 @@ func Test{{ class_name }}_{{ messagename }}(t *testing.T) {
 		Brokers:        []string{bootstrapServer},
 		Topic:          "{{ topic }}",
 		GroupID:        "test-consumer",
-		StartOffset:    kafka.LastOffset,
+		StartOffset:    kafka.FirstOffset,
 		CommitInterval: time.Second,
 	})
 	defer reader.Close()

--- a/xrcg/templates/go/mqttclient/go.mod.jinja
+++ b/xrcg/templates/go/mqttclient/go.mod.jinja
@@ -19,6 +19,7 @@ require (
 	github.com/username/{{ data_project_name | snake }} v0.0.0
 	{%- endif %}
 	github.com/stretchr/testify v1.8.4
+	github.com/testcontainers/testcontainers-go v0.27.0
 )
 
 {%- if uses_data_package %}

--- a/xrcg/templates/go/mqttclient/{testdir}client_test.go.jinja
+++ b/xrcg/templates/go/mqttclient/{testdir}client_test.go.jinja
@@ -16,12 +16,18 @@ package {{ project_name | snake }}_test
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/eclipse/paho.golang/paho"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	{%- if uses_data_package %}
 	{{ data_project_name | snake }} "github.com/username/{{ data_project_name | snake }}/pkg/{{ data_project_name }}"
@@ -38,6 +44,36 @@ type fakePublisher struct {
 func (f *fakePublisher) Publish(ctx context.Context, p *paho.Publish) (*paho.PublishResponse, error) {
 	f.publishes = append(f.publishes, p)
 	return &paho.PublishResponse{}, nil
+}
+
+func startMosquittoBroker(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "mosquitto.conf")
+	require.NoError(t, os.WriteFile(configPath, []byte("listener 1883\nallow_anonymous true\n"), 0o644))
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "eclipse-mosquitto:2",
+			ExposedPorts: []string{"1883/tcp"},
+			Files: []testcontainers.ContainerFile{
+				{
+					HostFilePath:      configPath,
+					ContainerFilePath: "/mosquitto/config/mosquitto.conf",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForListeningPort("1883/tcp"),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "1883/tcp")
+	require.NoError(t, err)
+
+	return container, fmt.Sprintf("mqtt://%s:%s", host, port.Port())
 }
 
 {%- for messagegroupid, messagegroup in root.messagegroups.items() %}
@@ -71,6 +107,117 @@ func Test{{ class_name }}SubscriptionTopicsCompile(t *testing.T) {
 		assert.NotContains(t, topic, "{")
 	}
 }
+
+{%- if loop.first %}
+{%- set first_messageids = [] %}
+{%- set first_messages = [] %}
+{%- for messageid, message in messagegroup.messages.items() %}
+{%- if not first_messageids %}
+{%- set _ = first_messageids.append(messageid) %}
+{%- set _ = first_messages.append(message) %}
+{%- endif %}
+{%- endfor %}
+{%- if first_messageids %}
+{%- set first_messageid = first_messageids[0] %}
+{%- set first_message = first_messages[0] %}
+{%- set first_messagename = first_messageid | pascal | strip_namespace %}
+{%- set first_message_body_type = mqtt.body_type(data_project_name, root, first_message) %}
+{%- set first_topic = mqtt.get_topic(first_message) or first_messageid %}
+{%- set first_isCloudEvent = cloudEvents.isCloudEvent(first_message) %}
+{%- set first_topic_vars = [] %}
+{%- for ph in first_topic | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+{%- if ph not in first_topic_vars %}
+{%- set _ = first_topic_vars.append(ph) %}
+{%- endif %}
+{%- endfor %}
+{%- set first_source_vars = [] %}
+{%- if first_isCloudEvent and first_message.envelopemetadata and "source" in first_message.envelopemetadata and first_message.envelopemetadata.source.value %}
+{%- for ph in first_message.envelopemetadata.source.value | regex_search('\\{([A-Za-z0-9_]+)\\}') %}
+{%- if ph not in first_topic_vars and ph not in first_source_vars %}
+{%- set _ = first_source_vars.append(ph) %}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- set first_extension_params = [] %}
+{%- if first_isCloudEvent and first_message.envelopemetadata %}
+{%- for attrname, attribute in first_message.envelopemetadata.items() if attrname not in ["source", "type", "id", "time", "specversion", "datacontenttype"] and not attribute.value %}
+{%- set _ = first_extension_params.append(attrname) %}
+{%- endfor %}
+{%- endif %}
+{%- set first_needs_source_param = first_isCloudEvent and (not first_message.envelopemetadata or "source" not in first_message.envelopemetadata) %}
+{%- set first_needs_type_param = first_isCloudEvent and (not first_message.envelopemetadata or "type" not in first_message.envelopemetadata) %}
+type {{ class_name | lower }}IntegrationHandler struct {
+	received chan string
+	errors   chan error
+}
+
+{%- for messageid, message in messagegroup.messages.items() %}
+{%- set messagename = messageid | pascal | strip_namespace %}
+{%- set message_body_type = mqtt.body_type(data_project_name, root, message) %}
+{%- set isCloudEvent = cloudEvents.isCloudEvent(message) %}
+{%- if isCloudEvent %}
+func (h *{{ class_name | lower }}IntegrationHandler) Handle{{ messagename }}(ctx context.Context, event cloudevents.Event, data {{ message_body_type }}, topicParams map[string]string) error {
+{%- else %}
+func (h *{{ class_name | lower }}IntegrationHandler) Handle{{ messagename }}(ctx context.Context, data {{ message_body_type }}, topicParams map[string]string) error {
+{%- endif %}
+	{%- if loop.first %}
+	h.received <- "{{ messageid }}"
+	{%- endif %}
+	return nil
+}
+{%- endfor %}
+
+func (h *{{ class_name | lower }}IntegrationHandler) HandleError(ctx context.Context, err error) {
+	h.errors <- err
+}
+
+func Test{{ class_name }}IntegrationRoundTrip(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	for _, tc := range []struct {
+		name        string
+		contentMode ContentMode
+	}{
+		{name: "Structured", contentMode: ContentModeStructured},
+		{name: "Binary", contentMode: ContentModeBinary},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			container, brokerURL := startMosquittoBroker(t, ctx)
+			defer func() {
+				require.NoError(t, container.Terminate(context.Background()))
+			}()
+
+			client, err := New{{ class_name }}(ctx, brokerURL, "test-client-"+tc.name, tc.contentMode)
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, client.Close(context.Background()))
+			}()
+
+			handler := &{{ class_name | lower }}IntegrationHandler{
+				received: make(chan string, 1),
+				errors:   make(chan error, 1),
+			}
+			require.NoError(t, client.Subscribe(ctx, handler, []string{"#"}, 1))
+
+			var data {{ first_message_body_type }}
+			require.NoError(t, client.Publish{{ first_messagename }}(ctx, data{% for var in first_topic_vars %}, "test-{{ var }}"{% endfor %}{% for var in first_source_vars %}, "test-{{ var }}"{% endfor %}{% if first_needs_source_param %}, "test-source"{% endif %}{% if first_needs_type_param %}, "{{ first_messageid }}"{% endif %}{% for attr in first_extension_params %}, "test-{{ attr }}"{% endfor %}))
+
+			select {
+			case received := <-handler.received:
+				require.Equal(t, "{{ first_messageid }}", received)
+			case err := <-handler.errors:
+				require.NoError(t, err)
+			case <-time.After(15 * time.Second):
+				require.Fail(t, "timed out waiting for MQTT round-trip")
+			}
+		})
+	}
+}
+{%- endif %}
+{%- endif %}
 
 {%- for messageid, message in messagegroup.messages.items() %}
 {%- set messagename = messageid | pascal | strip_namespace %}


### PR DESCRIPTION
## Summary

Two related changes:

### 1. `azure_cbs_target` codegen switch (original PR scope)

Adds an `--template-args azure_cbs_target=eventhubs|servicebus` switch to the Python `amqpproducer` template that wires in **AMQP CBS (Claims-Based Security) put-token** flow using `azure-identity` token credentials. Required for Entra ID auth against Azure Event Hubs and Service Bus.

### 2. Windows TLS-1.3 patched proton wheel (new)

The official `python-qpid-proton` PyPI Windows wheel links against SChannel via the deprecated `SCHANNEL_CRED` API and **cannot negotiate TLS 1.3**. Azure Service Bus namespaces with `minimumTlsVersion=1.3` therefore reject the connection at AMQP open with `amqp:unauthorized-access "Invalid TLS version"`. Tracked upstream at https://issues.apache.org/jira/projects/PROTON (issue draft pending submission).

Until upstream proton ships a fixed Windows wheel, this PR publishes our own:

- `tools/proton-windows-wheel/build.py` — downloads the proton sdist, patches `ext_build.py` to compile `ssl/openssl.c` instead of `ssl/schannel.cpp` on Windows, sets PEP 440 local version `0.40.0+xrcgN`, runs `python -m build --wheel`.
- `.github/workflows/build-proton-windows-wheels.yml` — matrix build over cp310/cp311/cp312/cp313 × `win_amd64`, installs OpenSSL via cached vcpkg, uploads wheels as artifacts, and on `workflow_dispatch` publishes a GitHub Release tagged `proton-windows-<ver>+xrcgN`. Also runs on PRs that touch the pipeline files so changes are validated before merge.
- `scripts/build_wheel_index.py` — scans `proton-windows-*` releases via the GitHub REST API and emits a PEP 503 simple index.
- `publish-pages.yml` — extended to trigger on release events and drop the simple index under `_site/wheels/`. Result: pip can use `--extra-index-url https://xregistry.github.io/codegen/wheels/simple/`.
- Generated README documents the Windows install line; Linux/macOS install is unchanged because the local version `0.40.0+xrcg1` is only ever found at our index.

### When this comes down

The day upstream qpid-proton publishes a Windows wheel that supports TLS 1.3 (likely via the modern `SCH_CREDENTIALS` + `TLS_PARAMETERS` API), we stop building our wheel, bump the floor in generated `pyproject.toml`, and remove the `--extra-index-url` note. Documented in `tools/proton-windows-wheel/README.md`.

## Testing

- Wheel pipeline runs on this PR (path-filtered trigger) — see Actions tab.
- Patcher unit-dryrun verified that the regex substitutions on `ext_build.py` find their targets on proton 0.40.0.
- The CBS implementation was live-validated against Event Hubs (TLS 1.2) and Service Bus (TLS 1.3 — when paired with the patched wheel) in earlier session work.

## Out of scope

- Mirror to amqpconsumer + Java/C#/TS — follow-up PRs.