### PR TITLE
Resolve xRegistry resource aliases (xref) transparently to codegen (#582)

### DIFF
--- a/docs/alias_resolution.md
+++ b/docs/alias_resolution.md
@@ -1,0 +1,75 @@
+# Resource Alias Resolution Feature
+
+This document describes the resource alias resolution feature in the xRegistry
+Code Generation CLI, which follows the [xRegistry Core Specification —
+Cross Referencing Resources](https://github.com/xregistry/spec/blob/main/core/spec.md#cross-referencing-resources).
+
+## Overview
+
+An xRegistry resource can be an **alias** of another, same-typed resource in the
+same registry. Instead of declaring its own `versions`/`versionsurl`, an alias
+resource carries an `xref` attribute whose value is an XID pointing at the
+canonical resource, for example:
+
+```json
+{
+  "schemagroups": {
+    "route": {
+      "schemas": {
+        "EventData": {
+          "meta": { "xref": "/schemagroups/canonical/schemas/EventData" }
+        }
+      }
+    }
+  }
+}
+```
+
+The alias projects the target resource's metadata, versions, default version,
+and document through the alias identity.
+
+## How It Works
+
+Alias resolution runs inside the loader during document loading — **before**
+validation, schema processing, and template rendering — so aliases are
+completely transparent to code generation. Each alias resource is replaced in
+place by a deep copy of its target's content, while the alias retains its own
+identity (its collection key and `<singular>id`, e.g. `schemaid`/`messageid`).
+
+Because resolution happens before validation, a document whose only otherwise
+"invalid" content is an `xref` alias validates cleanly against the document
+schema.
+
+### Where `xref` may appear
+
+Both forms are honored:
+
+- A resource-level `xref` attribute.
+- An `xref` inside the resource's `meta` sub-object (`meta.xref`) — the form
+  emitted when a resource has no versions of its own.
+
+### Model-driven
+
+Resolution is driven by the extension model, so it applies uniformly to every
+resource type — `schemas`, `messages`, and any custom resources — without
+hard-coding.
+
+### Non-transitive
+
+Per the Core specification, aliases are **not** resolved transitively. An alias
+that targets another alias is reported as an error; point aliases at canonical
+resources.
+
+## Diagnostics
+
+When an alias cannot be resolved, the loader logs an actionable error and leaves
+the alias untouched (so downstream validation still flags the unresolved
+resource). Reported conditions are:
+
+- **Malformed target** — the `xref` is not an XID of the form
+  `/<group>/<groupid>/<resource>/<resourceid>`.
+- **Missing target** — the target XID does not exist in the document.
+- **Type mismatch** — the target is a different resource type than the alias.
+- **Self-reference** — the `xref` points at the alias itself.
+- **Alias-to-alias** — the target is itself an alias (transitive resolution is
+  not performed).

--- a/test/core/test_alias_resolution.py
+++ b/test/core/test_alias_resolution.py
@@ -1,0 +1,245 @@
+"""Tests for xRegistry resource alias (xref) resolution.
+
+Aliases are resolved during document loading so they are transparent to
+validation, schema processing, and template rendering (see issue #582).
+"""
+
+import json
+import logging
+import os
+import tempfile
+import unittest
+
+from xrcg.generator.xregistry_loader import XRegistryLoader
+from xrcg.commands.validate_definitions import validate
+
+
+def _canonical_schema():
+    return {
+        "format": "JSONSchema/draft-07",
+        "defaultversionid": "1",
+        "versions": {
+            "1": {
+                "format": "JSONSchema/draft-07",
+                "schema": {
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                },
+            }
+        },
+    }
+
+
+class TestAliasResolution(unittest.TestCase):
+    """Resource alias (xref) resolution during load."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        for file in os.listdir(self.temp_dir):
+            os.remove(os.path.join(self.temp_dir, file))
+        os.rmdir(self.temp_dir)
+
+    def _write(self, doc):
+        path = os.path.join(self.temp_dir, "test.xreg.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(doc, f)
+        return path
+
+    def _load(self, doc):
+        path = self._write(doc)
+        loader = XRegistryLoader()
+        _, result = loader.load(path)
+        return result
+
+    def test_schema_alias_meta_xref_resolves(self):
+        """An alias authored as meta.xref projects the target's content."""
+        doc = {
+            "schemagroups": {
+                "canonical": {"schemas": {"EventData": _canonical_schema()}},
+                "route": {
+                    "schemas": {
+                        "EventData": {
+                            "meta": {"xref": "/schemagroups/canonical/schemas/EventData"}
+                        }
+                    }
+                },
+            }
+        }
+        result = self._load(doc)
+        alias = result["schemagroups"]["route"]["schemas"]["EventData"]
+
+        # Target content is projected through the alias.
+        self.assertIn("versions", alias)
+        self.assertEqual(alias["defaultversionid"], "1")
+        self.assertEqual(
+            alias["versions"]["1"]["schema"]["properties"]["value"]["type"], "string"
+        )
+        # The alias retains its own identity.
+        self.assertEqual(alias["schemaid"], "EventData")
+        # xref markers are gone.
+        self.assertNotIn("xref", alias)
+        self.assertNotIn("meta", alias)
+
+    def test_resource_level_xref_resolves(self):
+        """An alias authored as a resource-level xref also resolves."""
+        doc = {
+            "schemagroups": {
+                "canonical": {"schemas": {"EventData": _canonical_schema()}},
+                "route": {
+                    "schemas": {
+                        "Aliased": {"xref": "/schemagroups/canonical/schemas/EventData"}
+                    }
+                },
+            }
+        }
+        result = self._load(doc)
+        alias = result["schemagroups"]["route"]["schemas"]["Aliased"]
+        self.assertIn("versions", alias)
+        self.assertEqual(alias["schemaid"], "Aliased")
+
+    def test_message_alias_resolves(self):
+        """Aliases are model-driven and work for messages, not only schemas."""
+        doc = {
+            "messagegroups": {
+                "canonical": {
+                    "messages": {
+                        "OrderCreated": {
+                            "envelope": "CloudEvents/1.0",
+                            "envelopemetadata": {
+                                "type": {"value": "com.example.order.created"}
+                            },
+                        }
+                    }
+                },
+                "route": {
+                    "messages": {
+                        "OrderCreated": {
+                            "meta": {
+                                "xref": "/messagegroups/canonical/messages/OrderCreated"
+                            }
+                        }
+                    }
+                },
+            }
+        }
+        result = self._load(doc)
+        alias = result["messagegroups"]["route"]["messages"]["OrderCreated"]
+        self.assertEqual(alias["envelope"], "CloudEvents/1.0")
+        self.assertEqual(
+            alias["envelopemetadata"]["type"]["value"], "com.example.order.created"
+        )
+        self.assertEqual(alias["messageid"], "OrderCreated")
+        self.assertNotIn("meta", alias)
+
+    def test_alias_document_validates(self):
+        """A document whose only alias content is meta.xref validates cleanly."""
+        doc = {
+            "schemagroups": {
+                "canonical": {"schemas": {"EventData": _canonical_schema()}},
+                "route": {
+                    "schemas": {
+                        "EventData": {
+                            "meta": {"xref": "/schemagroups/canonical/schemas/EventData"}
+                        }
+                    }
+                },
+            }
+        }
+        path = self._write(doc)
+        self.assertEqual(validate([path], {}, verbose=False), 0)
+
+    # --- error diagnostics -------------------------------------------------
+
+    def _assert_unresolved_with_error(self, doc, needle):
+        path = self._write(doc)
+        loader = XRegistryLoader()
+        with self.assertLogs(
+            "xrcg.generator.xregistry_loader.AliasResolver", level="ERROR"
+        ) as cm:
+            _, result = loader.load(path)
+        self.assertTrue(any(needle in m for m in cm.output), cm.output)
+        return result
+
+    def test_malformed_target(self):
+        doc = {
+            "schemagroups": {
+                "route": {"schemas": {"Alias": {"meta": {"xref": "not-an-xid"}}}}
+            }
+        }
+        result = self._assert_unresolved_with_error(doc, "malformed xref target")
+        # Alias left untouched so downstream validation still flags it.
+        self.assertIn(
+            "xref", result["schemagroups"]["route"]["schemas"]["Alias"]["meta"]
+        )
+
+    def test_missing_target(self):
+        doc = {
+            "schemagroups": {
+                "canonical": {"schemas": {"EventData": _canonical_schema()}},
+                "route": {
+                    "schemas": {
+                        "Alias": {
+                            "meta": {"xref": "/schemagroups/canonical/schemas/Nope"}
+                        }
+                    }
+                },
+            }
+        }
+        self._assert_unresolved_with_error(doc, "was not found")
+
+    def test_type_mismatch(self):
+        doc = {
+            "schemagroups": {
+                "route": {
+                    "schemas": {
+                        "Alias": {
+                            "meta": {
+                                "xref": "/messagegroups/canonical/messages/EventData"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self._assert_unresolved_with_error(doc, "different resource type")
+
+    def test_self_reference(self):
+        doc = {
+            "schemagroups": {
+                "route": {
+                    "schemas": {
+                        "Alias": {
+                            "meta": {"xref": "/schemagroups/route/schemas/Alias"}
+                        }
+                    }
+                }
+            }
+        }
+        self._assert_unresolved_with_error(doc, "refers to itself")
+
+    def test_alias_to_alias_not_transitive(self):
+        doc = {
+            "schemagroups": {
+                "canonical": {"schemas": {"EventData": _canonical_schema()}},
+                "route": {
+                    "schemas": {
+                        "First": {
+                            "meta": {"xref": "/schemagroups/route/schemas/Second"}
+                        },
+                        "Second": {
+                            "meta": {
+                                "xref": "/schemagroups/canonical/schemas/EventData"
+                            }
+                        },
+                    }
+                },
+            }
+        }
+        self._assert_unresolved_with_error(doc, "is itself an alias")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/xrcg/generator/xregistry_loader.py
+++ b/xrcg/generator/xregistry_loader.py
@@ -1,5 +1,6 @@
 """ Core functions for the xregistry commands with dependency resolution """
 
+import copy
 import json
 import os
 from typing import Any, Dict, List, Tuple, Union, Set, Optional
@@ -946,6 +947,170 @@ class MessageResolver:
                 self.logger.error(f"Failed to resolve basemessage for: {message_id} (circular reference)")
 
 
+class AliasResolver:
+    """Resolves xRegistry resource aliases so they are transparent to codegen.
+
+    A resource alias is defined by the xRegistry Core specification under
+    *Cross Referencing Resources*. An alias resource carries an ``xref``
+    attribute — either at the resource level or inside the resource's ``meta``
+    sub-object — whose value is an XID naming a *same-typed* resource in the
+    same registry document, e.g. ``/schemagroups/canonical/schemas/EventData``.
+    The alias projects the target's metadata, versions, default version, and
+    document through the alias identity.
+
+    This resolver runs during document loading, before validation, schema
+    processing, and template rendering. Each alias resource is replaced in
+    place by a deep copy of its target's content while retaining the alias
+    resource's own identity (its collection key and ``<singular>id``). As a
+    result, downstream consumers never observe ``xref`` and a document whose
+    only "invalid" content was an alias validates cleanly against the document
+    schema.
+
+    Per the Core specification, aliases are **not** resolved transitively: an
+    alias that targets another alias is reported as an error, as are malformed
+    targets, missing targets, type mismatches, and self-references.
+    """
+
+    def __init__(self, loader: 'XRegistryLoader'):
+        self.loader = loader
+        self.model = loader.model
+        self.logger = logging.getLogger(__name__ + ".AliasResolver")
+
+    @staticmethod
+    def _get_xref(resource: Any) -> Optional[str]:
+        """Return the ``xref`` value of a resource, honoring both the
+        resource-level ``xref`` attribute and the ``meta.xref`` form. Returns
+        the first non-empty value found, or None."""
+        if not isinstance(resource, dict):
+            return None
+        xref = resource.get("xref")
+        if xref:
+            return xref
+        meta = resource.get("meta")
+        if isinstance(meta, dict):
+            meta_xref = meta.get("xref")
+            if meta_xref:
+                return meta_xref
+        return None
+
+    def _resource_plurals_by_group(self) -> Dict[str, Dict[str, Optional[str]]]:
+        """Build a lookup of ``group_plural -> {resource_plural: resource_singular}``
+        from the model so alias resolution works for every resource type
+        (messages, schemas, and any custom resources) without hard-coding."""
+        result: Dict[str, Dict[str, Optional[str]]] = {}
+        for group_plural, gdef in self.model.groups.items():
+            if not isinstance(gdef, dict):
+                continue
+            resources = gdef.get("resources", [])
+            plurals: Dict[str, Optional[str]] = {}
+            if isinstance(resources, list):
+                for r in resources:
+                    if isinstance(r, dict) and r.get("plural"):
+                        plurals[r["plural"]] = r.get("singular")
+            elif isinstance(resources, dict):
+                for rid, r in resources.items():
+                    if isinstance(r, dict):
+                        plurals[r.get("plural", rid)] = r.get("singular")
+            result[group_plural] = plurals
+        return result
+
+    def resolve_all_aliases(self, xreg_doc: Dict[str, Any]) -> None:
+        """Resolve every resource alias in the document in place."""
+        if not isinstance(xreg_doc, dict):
+            return
+
+        group_resource_plurals = self._resource_plurals_by_group()
+
+        for group_plural, groups in xreg_doc.items():
+            resource_plurals = group_resource_plurals.get(group_plural)
+            if not resource_plurals or not isinstance(groups, dict):
+                continue
+            for group_id, group in groups.items():
+                if not isinstance(group, dict):
+                    continue
+                for res_plural, res_singular in resource_plurals.items():
+                    collection = group.get(res_plural)
+                    if not isinstance(collection, dict):
+                        continue
+                    for res_id, resource in list(collection.items()):
+                        xref = self._get_xref(resource)
+                        if not xref:
+                            continue
+                        alias_path = f"/{group_plural}/{group_id}/{res_plural}/{res_id}"
+                        resolved = self._resolve_alias(
+                            xref, alias_path, res_plural, res_singular,
+                            res_id, xreg_doc)
+                        if resolved is not None:
+                            collection[res_id] = resolved
+
+    def _resolve_alias(self, xref: str, alias_path: str, res_plural: str,
+                       res_singular: Optional[str], alias_id: str,
+                       xreg_doc: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Resolve a single alias to a replacement resource, or return None
+        (leaving the alias untouched) and log an actionable error on failure."""
+        target = xref.strip()
+        segments = [s for s in target.split("/") if s != ""]
+        # Expect an XID of the form /<group>/<groupid>/<resource>/<resourceid>.
+        if len(segments) != 4:
+            self.logger.error(
+                f"Alias {alias_path}: malformed xref target '{xref}'. Expected an "
+                f"XID of the form '/<group>/<groupid>/<resource>/<resourceid>'.")
+            return None
+
+        t_group_plural, t_group_id, t_res_plural, t_res_id = segments
+        target_path = f"/{t_group_plural}/{t_group_id}/{t_res_plural}/{t_res_id}"
+
+        # Type check: the target must name a same-typed resource.
+        if t_res_plural != res_plural:
+            self.logger.error(
+                f"Alias {alias_path}: xref target '{target_path}' is a different "
+                f"resource type ('{t_res_plural}' vs '{res_plural}'). Aliases must "
+                f"target a same-typed resource.")
+            return None
+
+        # Self-reference.
+        if target_path == alias_path:
+            self.logger.error(
+                f"Alias {alias_path}: xref target refers to itself.")
+            return None
+
+        # Navigate to the target resource in the same document.
+        groups = xreg_doc.get(t_group_plural)
+        target_group = groups.get(t_group_id) if isinstance(groups, dict) else None
+        target_collection = (
+            target_group.get(t_res_plural) if isinstance(target_group, dict) else None)
+        target_resource = (
+            target_collection.get(t_res_id) if isinstance(target_collection, dict) else None)
+        if not isinstance(target_resource, dict):
+            self.logger.error(
+                f"Alias {alias_path}: xref target '{target_path}' was not found in "
+                f"the registry document.")
+            return None
+
+        # Core does not perform transitive alias resolution.
+        if self._get_xref(target_resource):
+            self.logger.error(
+                f"Alias {alias_path}: xref target '{target_path}' is itself an "
+                f"alias. Core does not perform transitive alias resolution; point "
+                f"the alias at a canonical resource.")
+            return None
+
+        # Project the target through the alias identity.
+        resolved = copy.deepcopy(target_resource)
+        if res_singular:
+            resolved[f"{res_singular}id"] = alias_id
+        for key in ("xref", "self", "xid"):
+            resolved.pop(key, None)
+        meta = resolved.get("meta")
+        if isinstance(meta, dict):
+            meta.pop("xref", None)
+            if not meta:
+                resolved.pop("meta", None)
+
+        self.logger.info(f"Resolved alias {alias_path} -> {target_path}")
+        return resolved
+
+
 class XRegistryLoader:
     """Main loader class for xRegistry documents with dependency resolution."""
     
@@ -954,6 +1119,7 @@ class XRegistryLoader:
         self.dependency_resolver = DependencyResolver(self.model, self)
         self.resource_resolver = ResourceResolver(self)
         self.message_resolver = MessageResolver(self)
+        self.alias_resolver = AliasResolver(self)
         self.logger = logging.getLogger(__name__ + ".XRegistryLoader")
         
         # Schema handling state for template rendering compatibility
@@ -1077,6 +1243,10 @@ class XRegistryLoader:
             # Apply basic resource resolution
             self.resource_resolver.resolve_all_resources(document, headers)
             
+            # Resolve resource aliases (xref) so they are transparent to codegen
+            if isinstance(document, dict):
+                self.alias_resolver.resolve_all_aliases(document)
+            
             # Resolve basemessage references
             if isinstance(document, dict):
                 self.message_resolver.resolve_all_basemessages(document)
@@ -1154,6 +1324,10 @@ class XRegistryLoader:
             
             if stacked_document is None:
                 return uris[0], None
+            
+            # Resolve resource aliases (xref) so they are transparent to codegen
+            if isinstance(stacked_document, dict):
+                self.alias_resolver.resolve_all_aliases(stacked_document)
             
             # Resolve basemessage references in the final stacked document
             if isinstance(stacked_document, dict):
@@ -1348,6 +1522,10 @@ class XRegistryLoader:
             
             # Resolve all individual resource references (like schemaurl, resourceurl)
             self.resource_resolver.resolve_all_resources(composed_document, headers)
+            
+            # Resolve resource aliases (xref) so they are transparent to codegen
+            if isinstance(composed_document, dict):
+                self.alias_resolver.resolve_all_aliases(composed_document)
             
             # Resolve basemessage references
             if isinstance(composed_document, dict):


### PR DESCRIPTION
## Summary

Fixes #582. `xrcg` rejected xRegistry resource **aliases** expressed with the Core `meta.xref` attribute because the document schema requires every resource to declare `versions`/`versionsurl`. As a result, generation could not follow a schema (or message) alias to its canonical resource.

This PR makes aliases **transparent to code generation**: they are resolved during document loading, before validation, schema processing, and template rendering.

## Approach

A new `AliasResolver` in `xregistry_loader.py`:

- **Model-driven** — resolves aliases for every resource type (`schemas`, `messages`, and any custom resources) using the extension model; nothing is hard-coded.
- Honors both a resource-level `xref` and the `meta.xref` form.
- Replaces each alias in place with a deep copy of the target's content (versions, default version, document, body attributes) while **retaining the alias identity** (its collection key and `<singular>id`, e.g. `schemaid`/`messageid`).
- Wired into `load`, `load_stacked`, and `load_with_dependencies` — right after resource resolution and before basemessage resolution.
- Because aliases are resolved **before** validation, alias-only documents now validate cleanly against the existing document schema — **no schema change required**.
- **Non-transitive** per the Core spec. Actionable diagnostics for malformed, missing, type-mismatched, self-referential, and alias-to-alias targets; on failure the alias is left untouched so downstream validation still flags it.

## Behavior against the issue's expectations

1. ✅ Validation accepts an alias resource authored as `meta.xref` (resolved pre-validation).
2. ✅ The target XID resolves to a same-typed resource in the same registry.
3. ✅ A message referencing the alias generates using the canonical target's default version and schema document.
4. ✅ Generated names/navigation retain the alias resource identity.
5. ✅ Malformed / missing / type-mismatch / self-reference / alias-to-alias produce actionable diagnostics; no transitive resolution.

## Tests

`test/core/test_alias_resolution.py` — 9 cases:
- schema alias (`meta.xref`) resolution + identity retention
- resource-level `xref` resolution
- message alias resolution (model-driven)
- end-to-end `validate()` returns 0 for an alias-only document
- all five error diagnostics (malformed, missing, type mismatch, self-reference, non-transitive alias-to-alias)

Verified manually end-to-end: `xrcg validate` passes and `xrcg generate --language py --style kafkaproducer` produces a data class from the resolved alias schema. Existing loader/basemessage tests (66) still pass.

## Docs

Adds `docs/alias_resolution.md` (mirrors `docs/basemessage_resolution.md`).

Refs #582.
